### PR TITLE
Fix macOS CI: scope CXXFLAGS to aarch64-apple-darwin and add -isysroot

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,10 +5,15 @@ rustflags = ["-Ctarget-feature=+crt-static"]
 # macOS Tahoe (Darwin 25 / SDK 26.x): Apple clang with --target=arm64-apple-macosx
 # drops the C++ stdlib include search path when the SDK is >= 26.  The snappy_src
 # build script (pulled in via blosc) fails with "fatal error: 'string' file not
-# found" unless we restore the path explicitly.  Using the stable MacOSX.sdk
-# symlink so this survives minor SDK updates.
+# found" unless we restore the path explicitly.  We use -isysroot so the C stdlib
+# headers (stdlib.h, wchar.h, etc.) are also found from the same SDK — without it,
+# the libc++ wrappers silently lose symbols via _LIBCPP_USING_IF_EXISTS, producing
+# "unknown type name 'ldiv_t'" and similar errors when SDKROOT is unset (e.g. CI).
+# Using the stable MacOSX.sdk symlink so this survives minor SDK updates.
+# cc-rs reads CXXFLAGS_<triple_underscored> before the generic CXXFLAGS, so this
+# is scoped to aarch64-apple-darwin and does not bleed into Linux builds.
 [target.aarch64-apple-darwin]
 rustflags = []
 
 [env]
-CXXFLAGS = "-I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1"
+CXXFLAGS_aarch64_apple_darwin = "-isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk -I/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1"


### PR DESCRIPTION
The global CXXFLAGS=-I... workaround for macOS Tahoe (SDK 26.x dropping the C++ include path) caused snappy_src to fail in CI with errors like "unknown type name 'ldiv_t'" and "reference to unresolved using declaration".

Root cause: adding -I for the C++ headers without -isysroot means libc++'s _LIBCPP_USING_IF_EXISTS wrappers silently lose C stdlib symbols when SDKROOT is unset (GitHub Actions runners don't set SDKROOT).  Local builds were fine because Xcode's shell sets SDKROOT automatically.

Fix:
- Switch CXXFLAGS -> CXXFLAGS_aarch64_apple_darwin (cc-rs target-specific env var, not picked up by Linux builds).
- Add -isysroot pointing at the same SDK so that C stdlib headers (stdlib.h, wchar.h, etc.) resolve from the same SDK as the C++ headers.