### PR TITLE
Add recursive OME-Zarr querying and bioimage coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__
 .claude/
 .mcp.json
 test/fixtures/xarray_tutorial
+test/fixtures/bioimage
 
 # CCE (code-context-engine)
 # CCE local cache (per-machine, not for version control)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ SELECT * FROM 'https://example.com/data.zarr';
 -- Explicit table function with optional dims= for multi-group stores
 SELECT * FROM read_zarr('path/to/store.zarr', dims=['time', 'lat', 'lon']);
 
+-- Select one array by its store-relative path (including nested arrays)
+SELECT * FROM read_zarr('image.ome.zarr', array_path='labels/nuclei/0');
+
 -- Inspect arrays in a store
 SELECT name, role, dtype, shape FROM read_zarr_metadata('path/to/store.zarr');
 
@@ -23,7 +26,8 @@ SELECT name, role, dtype, shape FROM read_zarr_metadata('path/to/store.zarr');
 SELECT * FROM read_zarr_groups('path/to/store.zarr');
 ```
 
-See [docs/design.md](docs/design.md) for the full design.
+See [docs/design.md](docs/design.md) for the full design and
+[docs/ome-zarr.md](docs/ome-zarr.md) for a small bioimage example.
 
 ## Status
 
@@ -31,7 +35,7 @@ Active development. Phases 1–3 are implemented:
 
 - **Phase 1** — `read_zarr`, `read_zarr_metadata`, `read_zarr_groups` table functions; Zarr v3; CF conventions (fill values, scale/offset, bounds variables, aux coords)
 - **Phase 2** — Zarr v2, Blosc/LZ4, replacement scan for local `.zarr` paths, projection pushdown
-- **Phase 3** — HTTP/HTTPS stores, `dims=` named parameter for multi-group selection
+- **Phase 3** — HTTP/HTTPS stores, `dims=` and `array_path=` selection, recursive array discovery
 
 See the [phased plan](docs/design.md#phased-plan) for what's next.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,10 @@ SELECT * FROM read_zarr('/path/to/my/array.zarr')
 WHERE dimension_0 > 100 AND dimension_1 < 50;
 ```
 
+For a small bioimage walkthrough, see [Querying OME-Zarr](ome-zarr.md).
+For the domains covered by the current test suite, see
+[Tested scientific domains](domains.md).
+
 ## Development Setup
 
 ```shell

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,33 @@ For a small bioimage walkthrough, see [Querying OME-Zarr](ome-zarr.md).
 For the domains covered by the current test suite, see
 [Tested scientific domains](domains.md).
 
+### OME-Zarr Features
+
+OME-Zarr stores often contain nested arrays for resolution levels and labels.
+Use metadata discovery first to see the available store-relative paths:
+
+```sql
+SELECT name, dims, shape, dtype
+FROM read_zarr_metadata('/path/to/image.ome.zarr');
+```
+
+Then pass `array_path=` when you want a specific image or label array:
+
+```sql
+SELECT c, AVG("0") AS mean_intensity
+FROM read_zarr('/path/to/image.ome.zarr', array_path='0')
+GROUP BY c;
+
+SELECT "labels/nuclei/0" AS label, COUNT(*) AS pixels
+FROM read_zarr('/path/to/image.ome.zarr', array_path='labels/nuclei/0')
+WHERE "labels/nuclei/0" > 0
+GROUP BY label;
+```
+
+`array_path` is optional for simple stores where the reader can infer a single
+compatible array group. It becomes useful for multiscale images, nested labels,
+or stores with multiple incompatible array shapes.
+
 ## Development Setup
 
 ```shell

--- a/docs/design.md
+++ b/docs/design.md
@@ -13,7 +13,7 @@ A design for `duckdb-zarr` — a Rust DuckDB extension that lets users query Zar
 ## Non-goals (for the first cut)
 
 - Writes. Read-only.
-- Nested group hierarchies. We assume a flat Zarr group at the store root, with the xarray convention of sibling 1D coordinate arrays + nD data arrays. Multiple SQL tables can come out of that flat group (one per dim set, see below), but we don't recurse into subgroups.
+- Automatic relational joins across nested groups. Arrays are discovered recursively and can be selected by store-relative path, but each `read_zarr` scan still operates on one compatible dimension group or one explicitly selected array.
 - Replacing xarray. Users who need lazy array operations should keep using xarray; we just want a SQL handle on the same data.
 - Custom codecs beyond what `zarrs` already supports.
 - WebAssembly. The current scaffold ships a `wasm_lib.rs` target; it is not a supported build because `zarrs` and `ndarray` use threading and I/O patterns that don't trivially compile to `wasm32`. 
@@ -111,9 +111,15 @@ SELECT * FROM read_zarr(
   coords := ['t', 'y', 'x'],
   variables := ['u', 'v']
 );
+
+-- Pick one array, including a nested OME-Zarr level
+SELECT * FROM read_zarr('image.ome.zarr', array_path := 'labels/nuclei/0');
+
 ```
 
 Named arguments stay close to xarray's vocabulary (`variables`, `coords`, `chunks`, `dims`). Variables that share the requested dim set become one output column each, joined on coordinate index — exactly the xarray-sql `pivot()` shape. Variables outside that dim set are silently excluded; the user picks them up by querying a different `dims` group.
+
+`array_path` adds an unambiguous selector for multiscale OME-Zarr levels and nested labels. The same selector is accepted by `read_zarr_metadata` and `read_zarr_groups`. A quoted `"array"` alias is also registered; the quotes are required because `ARRAY` is a DuckDB keyword.
 
 ### 3. `ATTACH` for multi-group stores
 
@@ -428,7 +434,7 @@ CF-encoded time (e.g. `int64` + `units = "hours since 1970-01-01"` + `calendar =
 
 Within a dim group, two data variables might be chunked differently — e.g. `temperature[24,10,10]` and `humidity[1,20,20]`, both over `(time, lat, lon)`. The init phase enumerates a single cartesian product of chunk indices and so cannot align both grids without finer-grained iteration. Three options: (a) require uniform chunk shape per dim group, error at bind on mismatch; (b) plan against the coarsest chunk grid and re-read finer-chunked variables multiple times per work unit; (c) iterate at the row level rather than the chunk level.
 
-> **Decision (v1):** (a) — require uniform chunk shape across all selected variables in a dim group. Bind checks and fails with a message naming the offending pair, explaining the common cause (packed `int16` vs native `float32` storage from the source NetCDF), and pointing at the workaround (`read_zarr('store.zarr', variables := ['humidity'])`).
+> **Decision (v1):** (a) — require uniform chunk shape across all selected variables in a dim group. Bind checks and fails with a message naming the offending pair, explaining the common cause (packed `int16` vs native `float32` storage from the source NetCDF), and pointing at the workaround (`read_zarr('store.zarr', variables := ['humidity'])`). The new single-array equivalent is `read_zarr('store.zarr', array_path := 'humidity')`.
 >
 > **Empirical correction:** the original framing said this would "rarely be observed in practice." That was wrong. The `air_temperature_gradient` xarray tutorial dataset (NCEP reanalysis — same provenance as ERA5) has `Tair` chunked `[730, 13, 27]` while `dTdx`/`dTdy` share dims but are chunked `[730, 7, 27]`, because xarray preserves source-NetCDF chunking per variable and packed-vs-native storage routinely produces different chunks. This is common in atmospheric reanalysis stores, not exotic.
 >

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -1,0 +1,19 @@
+# Tested scientific domains
+
+`duckdb-zarr` reads Zarr and xarray conventions rather than implementing
+domain-specific query engines. Domain coverage therefore means that the test
+suite includes representative data and queries from that community.
+
+| Community | Current test coverage |
+| --- | --- |
+| Atmospheric and climate science | Xarray air-temperature data, an ERA5-style multidimensional dataset, named coordinates, packed values, and dimension-group selection. |
+| Ocean and climate science | ERSST sea-surface temperature and basin-mask data, including CF bounds and missing-value handling. |
+| Bioimaging | An OME-Zarr v3 multichannel image with a nested label image, including recursive discovery, resolution-level selection, named image axes, and label queries. |
+| General xarray/Zarr users | Synthetic Zarr v2 and v3 fixtures covering numeric types, sparse chunks, scalar coordinates, endianness, and compression. |
+
+The format may work for other communities, including astronomy, genomics, and
+remote sensing, but those domains do not yet have representative fixtures in
+the test suite. Support claims should follow the addition of domain-specific
+test data and queries.
+
+See [Querying OME-Zarr](ome-zarr.md) for the current bioimage example.

--- a/docs/domains.md
+++ b/docs/domains.md
@@ -16,4 +16,8 @@ remote sensing, but those domains do not yet have representative fixtures in
 the test suite. Support claims should follow the addition of domain-specific
 test data and queries.
 
+GeoZarr-style pyramids are a likely next area to evaluate because they share
+some structural patterns with OME-Zarr multiscales, but they are not currently
+covered by fixtures.
+
 See [Querying OME-Zarr](ome-zarr.md) for the current bioimage example.

--- a/docs/ome-zarr.md
+++ b/docs/ome-zarr.md
@@ -8,6 +8,10 @@ SELECT name, dims, shape, dtype
 FROM read_zarr_metadata('image.ome.zarr');
 ```
 
+The `array_path` argument is optional. Use it when a store has multiple
+resolution levels, nested labels, or otherwise ambiguous array groups. The path
+is the same store-relative path reported by `read_zarr_metadata`.
+
 Then select a resolution level and aggregate a region by channel:
 
 ```sql

--- a/docs/ome-zarr.md
+++ b/docs/ome-zarr.md
@@ -1,0 +1,32 @@
+# Querying OME-Zarr
+
+OME-Zarr images commonly contain several resolution levels and nested label
+arrays. Start by listing the available arrays:
+
+```sql
+SELECT name, dims, shape, dtype
+FROM read_zarr_metadata('image.ome.zarr');
+```
+
+Then select a resolution level and aggregate a region by channel:
+
+```sql
+SELECT c, AVG("0") AS mean_intensity
+FROM read_zarr('image.ome.zarr', array_path='0')
+WHERE y BETWEEN 100 AND 199
+  AND x BETWEEN 200 AND 299
+GROUP BY c;
+```
+
+Here, `0` is the conventional path for the highest-resolution level. Xarray
+dimension names such as `c`, `y`, and `x` become SQL columns. Numeric and nested
+array names must be double-quoted when referenced as columns.
+
+Nested label arrays use the same selector:
+
+```sql
+SELECT "labels/nuclei/0" AS label, COUNT(*) AS pixels
+FROM read_zarr('image.ome.zarr', array_path='labels/nuclei/0')
+WHERE "labels/nuclei/0" > 0
+GROUP BY label;
+```

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -8,7 +8,9 @@ See docs/design.md §Bind phase and §Type mapping for the requirements.
 Usage:
     uv run scripts/generate_fixtures.py
 
-Output: test/fixtures/xarray_tutorial/<name>.zarr
+Output:
+    test/fixtures/xarray_tutorial/<name>.zarr
+    test/fixtures/bioimage/ome_zarr/<name>.ome.zarr
 
 Note on base64-encoded _FillValue: xarray encodes ALL float _FillValue attrs
 as base64 when writing zarr v3 — including non-NaN values like -9.97e36.
@@ -61,6 +63,7 @@ import zarr
 
 ROOT = pathlib.Path(__file__).parent.parent
 FIXTURES = ROOT / "test" / "fixtures" / "xarray_tutorial"
+BIOIMAGE_FIXTURES = ROOT / "test" / "fixtures" / "bioimage" / "ome_zarr"
 
 
 def write_zarr(ds: xr.Dataset, name: str, encoding: dict | None = None) -> None:
@@ -110,6 +113,106 @@ def open_tutorial(name: str, **kwargs) -> xr.Dataset:
 
 def main() -> None:
     FIXTURES.mkdir(parents=True, exist_ok=True)
+    BIOIMAGE_FIXTURES.mkdir(parents=True, exist_ok=True)
+
+    # ── synthetic_multichannel (OME-Zarr bioimage) ──────────────────────────
+    # A minimal two-channel microscopy image with OME multiscales metadata.
+    # Writing it through xarray records named dimensions in the Zarr v3 array,
+    # which read_zarr exposes directly as ergonomic c/y/x SQL columns.
+    print("synthetic_multichannel (OME-Zarr bioimage)...")
+    dest = BIOIMAGE_FIXTURES / "synthetic_multichannel.ome.zarr"
+    if not (dest / "zarr.json").exists():
+        if dest.exists():
+            _rmtree(dest)
+        pixels = np.concatenate([
+            np.arange(1, 13, dtype="uint16").reshape(1, 3, 4),
+            np.arange(101, 113, dtype="uint16").reshape(1, 3, 4),
+        ])
+        image = xr.DataArray(
+            pixels,
+            dims=["c", "y", "x"],
+            attrs={"long_name": "synthetic two-channel microscopy image"},
+        )
+        ds_bioimage = xr.Dataset(
+            {"0": image},
+            attrs={
+                "multiscales": [{
+                    "version": "0.5",
+                    "name": "synthetic_multichannel",
+                    "axes": [
+                        {"name": "c", "type": "channel"},
+                        {"name": "y", "type": "space", "unit": "micrometer"},
+                        {"name": "x", "type": "space", "unit": "micrometer"},
+                    ],
+                    "datasets": [{
+                        "path": "0",
+                        "coordinateTransformations": [{
+                            "type": "scale",
+                            "scale": [1.0, 0.65, 0.65],
+                        }],
+                    }],
+                }],
+                "omero": {
+                    "name": "synthetic_multichannel",
+                    "channels": [
+                        {"label": "DNA", "color": "0000FF"},
+                        {"label": "RNA", "color": "FFFF00"},
+                    ],
+                },
+            },
+        )
+        ds_bioimage.to_zarr(
+            dest,
+            zarr_format=3,
+            consolidated=False,
+            encoding={"0": {"chunks": [1, 2, 2]}},
+        )
+        print(f"  wrote {dest}")
+    else:
+        print(f"  (cached) {dest}")
+
+    # Add a nested OME-Zarr labels hierarchy. Keeping this as a separate xarray
+    # write exercises recursive discovery and store-relative array selection.
+    label_path = dest / "labels" / "nuclei" / "0" / "zarr.json"
+    if not label_path.exists():
+        xr.Dataset(attrs={"labels": ["nuclei"]}).to_zarr(
+            dest,
+            group="labels",
+            mode="a",
+            zarr_format=3,
+            consolidated=False,
+        )
+        labels = xr.DataArray(
+            np.array([
+                [0, 1, 1, 0],
+                [0, 1, 2, 2],
+                [0, 0, 2, 0],
+            ], dtype="uint8"),
+            dims=["y", "x"],
+            attrs={"image-label": {"source": {"image": "../../"}}},
+        )
+        xr.Dataset(
+            {"0": labels},
+            attrs={
+                "multiscales": [{
+                    "version": "0.5",
+                    "name": "nuclei",
+                    "axes": [
+                        {"name": "y", "type": "space", "unit": "micrometer"},
+                        {"name": "x", "type": "space", "unit": "micrometer"},
+                    ],
+                    "datasets": [{"path": "0"}],
+                }],
+            },
+        ).to_zarr(
+            dest,
+            group="labels/nuclei",
+            mode="a",
+            zarr_format=3,
+            consolidated=False,
+            encoding={"0": {"chunks": [2, 2]}},
+        )
+        print(f"  wrote nested labels to {dest}")
 
     # ── float_baseline (synthetic) ───────────────────────────────────────────
     # True float32 baseline with no packing, no sentinels.

--- a/scripts/generate_fixtures.py
+++ b/scripts/generate_fixtures.py
@@ -171,8 +171,10 @@ def main() -> None:
     else:
         print(f"  (cached) {dest}")
 
-    # Add a nested OME-Zarr labels hierarchy. Keeping this as a separate xarray
-    # write exercises recursive discovery and store-relative array selection.
+    # Add a nested OME-Zarr labels hierarchy. This is a dense integer label
+    # image, not a ragged array: each pixel stores 0 for background or an object
+    # id. Keeping this as a separate xarray write exercises recursive discovery
+    # and store-relative array selection.
     label_path = dest / "labels" / "nuclei" / "0" / "zarr.json"
     if not label_path.exists():
         xr.Dataset(attrs={"labels": ["nuclei"]}).to_zarr(

--- a/src/read_zarr.rs
+++ b/src/read_zarr.rs
@@ -6,8 +6,9 @@ use duckdb::core::{DataChunkHandle, LogicalTypeId};
 use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 
 use crate::zarr_reader::meta::{
-    build_column_defs, build_work_units, extract_file_system, infer_dim_groups, load_coord_array,
-    open_array, open_store, ZarrArray, ZarrStore,
+    build_column_defs, build_work_units, dim_group_for_array, dimension_names, extract_file_system,
+    infer_dim_groups, load_coord_array, open_array, open_store, select_array_name, ZarrArray,
+    ZarrStore,
 };
 use crate::zarr_reader::types::{ColumnDef, CoordArray, DimGroup, WorkUnit, ZarrDtype};
 
@@ -78,6 +79,16 @@ impl VTab for ReadZarrVTab {
             .get_named_parameter("dims")
             .map(|v| parse_dims_param(&v.to_string()))
             .transpose()?;
+        let array_path = bind
+            .get_named_parameter("array_path")
+            .map(|value| value.to_string());
+        let array_alias = bind
+            .get_named_parameter("array")
+            .map(|value| value.to_string());
+        if array_path.is_some() && array_alias.is_some() {
+            return Err("use either array_path= or \"array\"=, not both".into());
+        }
+        let requested_array = array_path.or(array_alias);
 
         let fs = unsafe { extract_file_system(bind) };
         let store = open_store(&store_path, Some(fs))?;
@@ -87,6 +98,21 @@ impl VTab for ReadZarrVTab {
             return Err(format!("no Zarr arrays found in '{store_path}'").into());
         }
 
+        if let Some(requested) = requested_array {
+            let array_name = select_array_name(&array_names, &requested)?;
+            let group = dim_group_for_array(&store, &array_names, &array_name)?;
+            if let Some(dims) = requested_dims {
+                if group.dims != dims {
+                    return Err(format!(
+                        "array '{array_name}' has dimensions {:?}, not {dims:?}",
+                        group.dims
+                    )
+                    .into());
+                }
+            }
+            return finish_bind(bind, store, &group);
+        }
+
         let (dim_groups, _coord_names) = infer_dim_groups(&store, &array_names)?;
 
         if dim_groups.is_empty() {
@@ -94,18 +120,16 @@ impl VTab for ReadZarrVTab {
         }
 
         let group = match requested_dims {
-            Some(ref dims) => {
-                dim_groups.iter().find(|g| g.dims == *dims).ok_or_else(|| {
-                    format!(
-                        "'{store_path}': no dimension group matches dims={dims:?}; available: {:?}",
-                        dim_groups.iter().map(|g| &g.dims).collect::<Vec<_>>()
-                    )
-                })?
-            }
+            Some(ref dims) => dim_groups.iter().find(|g| g.dims == *dims).ok_or_else(|| {
+                format!(
+                    "'{store_path}': no dimension group matches dims={dims:?}; available: {:?}",
+                    dim_groups.iter().map(|g| &g.dims).collect::<Vec<_>>()
+                )
+            })?,
             None => {
                 if dim_groups.len() > 1 {
                     return Err(format!(
-                        "'{store_path}' contains multiple dimension groups ({}) {:?}; use read_zarr(path, dims='[\"time\",\"lat\",\"lon\"]') to select one",
+                        "'{store_path}' contains multiple dimension groups ({}) {:?}; use dims= to select a compatible group or array_path= to select one array",
                         dim_groups.len(),
                         dim_groups.iter().map(|g| &g.dims).collect::<Vec<_>>()
                     ).into());
@@ -128,7 +152,8 @@ impl VTab for ReadZarrVTab {
         // DuckDB guarantees output.flat_vector(i) in scan() corresponds to
         // get_column_indices()[i] from init(). Do NOT sort — sorting destroys
         // the positional relationship and scrambles output in JOIN context.
-        let projected_cols: HashMap<usize, usize> = init.get_column_indices()
+        let projected_cols: HashMap<usize, usize> = init
+            .get_column_indices()
             .into_iter()
             .enumerate()
             .map(|(out_idx, col_idx)| (col_idx as usize, out_idx))
@@ -218,7 +243,11 @@ impl VTab for ReadZarrVTab {
     }
 
     fn named_parameters() -> Option<Vec<(String, duckdb::core::LogicalTypeHandle)>> {
-        Some(vec![("dims".to_string(), LogicalTypeId::Varchar.into())])
+        Some(vec![
+            ("dims".to_string(), LogicalTypeId::Varchar.into()),
+            ("array".to_string(), LogicalTypeId::Varchar.into()),
+            ("array_path".to_string(), LogicalTypeId::Varchar.into()),
+        ])
     }
 }
 
@@ -236,7 +265,11 @@ fn parse_dims_param(s: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> 
         let arr: Vec<String> = serde_json::from_str(trimmed)?;
         Ok(arr)
     } else {
-        Ok(trimmed.split(',').map(|d| d.trim().to_string()).filter(|d| !d.is_empty()).collect())
+        Ok(trimmed
+            .split(',')
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect())
     }
 }
 
@@ -249,7 +282,11 @@ fn finish_bind(
     let mut coord_arrays: HashMap<String, CoordArray> = HashMap::new();
     for coord_name in &group.coord_var_names {
         let ca = load_coord_array(&store, coord_name)?;
-        coord_arrays.insert(coord_name.clone(), ca);
+        let arr = open_array(&store, coord_name)?;
+        let dims = dimension_names(&arr, coord_name)?;
+        if let Some(dim) = dims.first() {
+            coord_arrays.insert(dim.clone(), ca);
+        }
     }
 
     let columns = build_column_defs(&store, group, &coord_arrays)?;
@@ -296,12 +333,15 @@ fn decode_work_unit(
         if !projected.contains_key(&col_idx) {
             continue; // skip decompression for non-projected data vars
         }
-        let arr = bind.arrays.get(&col.name)
+        let arr = bind
+            .arrays
+            .get(&col.name)
             .ok_or_else(|| format!("array '{}' not found in bind cache", col.name))?;
         // ArrayBytes<'static>: zarrs convention for requesting owned decoded bytes.
         // retrieve_chunk fills missing (implicit) chunks with fill_value automatically.
         let raw = arr.retrieve_chunk::<zarrs::array::ArrayBytes<'static>>(&wu.chunk_indices)?;
-        let bytes: Vec<u8> = raw.into_fixed()
+        let bytes: Vec<u8> = raw
+            .into_fixed()
             .map_err(|_| format!("variable-length dtype not supported for '{}'", col.name))?
             .into_owned();
         chunk_bytes.insert(col.name.clone(), bytes);
@@ -428,7 +468,10 @@ fn fill_chunk_slice(
                         dst,
                     );
                 } else {
-                    unreachable!("projected data variable '{}' missing from chunk_bytes", col_def.name);
+                    unreachable!(
+                        "projected data variable '{}' missing from chunk_bytes",
+                        col_def.name
+                    );
                 }
             }
         }
@@ -455,7 +498,10 @@ fn fill_data_element(
                 vector, bytes, dtype, sentinel, flat_row, elem_size, dst,
             );
         }
-        ColumnEncoding::PackedInt { scale_factor, add_offset } => {
+        ColumnEncoding::PackedInt {
+            scale_factor,
+            add_offset,
+        } => {
             let src = flat_row * elem_size;
             let raw = crate::zarr_reader::scan::read_int_as_i64_pub(bytes, dtype, src);
             let is_null = match sentinel {

--- a/src/read_zarr_groups.rs
+++ b/src/read_zarr_groups.rs
@@ -126,6 +126,9 @@ impl VTab for ReadZarrGroupsVTab {
     }
 
     fn named_parameters() -> Option<Vec<(String, duckdb::core::LogicalTypeHandle)>> {
+        // DuckDB named parameters are optional. These selectors narrow the
+        // discovered groups when present; omitting both returns all compatible
+        // groups discovered in the store.
         Some(vec![
             ("array".to_string(), LogicalTypeId::Varchar.into()),
             ("array_path".to_string(), LogicalTypeId::Varchar.into()),

--- a/src/read_zarr_groups.rs
+++ b/src/read_zarr_groups.rs
@@ -3,7 +3,10 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use duckdb::core::LogicalTypeId;
 use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 
-use crate::zarr_reader::meta::{extract_file_system, infer_dim_groups, list_array_names, open_store};
+use crate::zarr_reader::meta::{
+    dim_group_for_array, discover_dim_groups, extract_file_system, list_array_names, open_store,
+    select_array_name,
+};
 
 #[derive(Debug, Clone)]
 struct GroupRow {
@@ -45,7 +48,21 @@ impl VTab for ReadZarrGroupsVTab {
         let fs = unsafe { extract_file_system(bind) };
         let store = open_store(&store_path, Some(fs))?;
         let array_names = list_array_names(&store_path, &store)?;
-        let (dim_groups, _) = infer_dim_groups(&store, &array_names)?;
+        let array_path = bind
+            .get_named_parameter("array_path")
+            .map(|value| value.to_string());
+        let array_alias = bind
+            .get_named_parameter("array")
+            .map(|value| value.to_string());
+        if array_path.is_some() && array_alias.is_some() {
+            return Err("use either array_path= or \"array\"=, not both".into());
+        }
+        let dim_groups = if let Some(requested) = array_path.or(array_alias) {
+            let array_name = select_array_name(&array_names, &requested)?;
+            vec![dim_group_for_array(&store, &array_names, &array_name)?]
+        } else {
+            discover_dim_groups(&store, &array_names)?
+        };
 
         let rows = dim_groups
             .iter()
@@ -106,5 +123,12 @@ impl VTab for ReadZarrGroupsVTab {
 
     fn parameters() -> Option<Vec<duckdb::core::LogicalTypeHandle>> {
         Some(vec![LogicalTypeId::Varchar.into()])
+    }
+
+    fn named_parameters() -> Option<Vec<(String, duckdb::core::LogicalTypeHandle)>> {
+        Some(vec![
+            ("array".to_string(), LogicalTypeId::Varchar.into()),
+            ("array_path".to_string(), LogicalTypeId::Varchar.into()),
+        ])
     }
 }

--- a/src/read_zarr_metadata.rs
+++ b/src/read_zarr_metadata.rs
@@ -5,19 +5,19 @@ use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 
 use crate::zarr_reader::meta::{
     collect_auxiliary_coords, collect_bounds_vars, dimension_names as get_dim_names,
-    extract_file_system, list_array_names, open_array, open_store,
+    extract_file_system, list_array_names, open_array, open_store, select_array_name,
 };
 
 /// One metadata row per array.
 #[derive(Debug, Clone)]
 struct MetaRow {
     name: String,
-    dims: String,       // JSON array string e.g. '["lat","lon"]'
+    dims: String, // JSON array string e.g. '["lat","lon"]'
     dtype: String,
-    shape: String,      // JSON array string e.g. '[4,6]'
+    shape: String, // JSON array string e.g. '[4,6]'
     chunk_shape: String,
-    attrs: String,      // full attrs as JSON string
-    role: String,       // "coord" | "data" | "aux_coord" | "bounds" | "scalar" | "unknown"
+    attrs: String, // full attrs as JSON string
+    role: String,  // "coord" | "data" | "aux_coord" | "bounds" | "scalar" | "unknown"
 }
 
 pub struct ReadZarrMetaBind {
@@ -52,7 +52,19 @@ impl VTab for ReadZarrMetaVTab {
         let store_path = bind.get_parameter(0).to_string();
         let fs = unsafe { extract_file_system(bind) };
         let store = open_store(&store_path, Some(fs))?;
-        let array_names = list_array_names(&store_path, &store)?;
+        let mut array_names = list_array_names(&store_path, &store)?;
+        let array_path = bind
+            .get_named_parameter("array_path")
+            .map(|value| value.to_string());
+        let array_alias = bind
+            .get_named_parameter("array")
+            .map(|value| value.to_string());
+        if array_path.is_some() && array_alias.is_some() {
+            return Err("use either array_path= or \"array\"=, not both".into());
+        }
+        if let Some(requested) = array_path.or(array_alias) {
+            array_names = vec![select_array_name(&array_names, &requested)?];
+        }
 
         let aux_coords = collect_auxiliary_coords(&store, &array_names);
         let bounds_vars = collect_bounds_vars(&store, &array_names, &aux_coords);
@@ -84,7 +96,7 @@ impl VTab for ReadZarrMetaVTab {
                 "aux_coord"
             } else if shape.len() == 1
                 && dims.len() == 1
-                && dims[0] == *name
+                && dims[0] == *name.rsplit('/').next().unwrap_or(name)
             {
                 "coord"
             } else {
@@ -154,5 +166,12 @@ impl VTab for ReadZarrMetaVTab {
 
     fn parameters() -> Option<Vec<duckdb::core::LogicalTypeHandle>> {
         Some(vec![LogicalTypeId::Varchar.into()])
+    }
+
+    fn named_parameters() -> Option<Vec<(String, duckdb::core::LogicalTypeHandle)>> {
+        Some(vec![
+            ("array".to_string(), LogicalTypeId::Varchar.into()),
+            ("array_path".to_string(), LogicalTypeId::Varchar.into()),
+        ])
     }
 }

--- a/src/zarr_reader/meta.rs
+++ b/src/zarr_reader/meta.rs
@@ -67,7 +67,8 @@ pub fn open_store(
             unsafe { duckdb_destroy_file_system(&mut fs) };
         }
         Ok(Arc::new(zarrs_http::HTTPStore::new(path)?))
-    } else if lower.starts_with("s3://") || lower.starts_with("gs://") || lower.starts_with("az://") {
+    } else if lower.starts_with("s3://") || lower.starts_with("gs://") || lower.starts_with("az://")
+    {
         let fs = file_system.ok_or(
             "remote store requires a DuckDB FileSystem handle (call from a table function bind)",
         )?;
@@ -80,9 +81,9 @@ pub fn open_store(
     }
 }
 
-/// List the names of all top-level arrays in the Zarr store root.
+/// List the store-relative paths of all arrays in the Zarr hierarchy.
 ///
-/// - Local paths: scans for child directories containing `zarr.json` (v3) or `.zarray` (v2).
+/// - Local paths: recursively scans directories containing `zarr.json` (v3) or `.zarray` (v2).
 /// - Remote paths (HTTP/HTTPS/S3/GCS/Azure): reads consolidated metadata from the root zarr.json.
 pub fn list_array_names(
     store_path: &str,
@@ -98,35 +99,57 @@ pub fn list_array_names(
 fn list_array_names_local(store_path: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let root = Path::new(store_path);
     let mut names = Vec::new();
-    for entry in std::fs::read_dir(root)? {
+    collect_array_names_local(root, root, &mut names)?;
+    names.sort();
+    Ok(names)
+}
+
+fn collect_array_names_local(
+    root: &Path,
+    directory: &Path,
+    names: &mut Vec<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    for entry in std::fs::read_dir(directory)? {
         let entry = entry?;
         if !entry.file_type()?.is_dir() {
             continue;
         }
         let child_path = entry.path();
 
-        // Zarr v3: zarr.json present — check node_type to skip nested groups.
+        // Zarr v3: arrays are terminal; groups are traversed recursively.
         if child_path.join("zarr.json").exists() {
             let content = std::fs::read_to_string(child_path.join("zarr.json"))?;
             let meta: serde_json::Value = serde_json::from_str(&content)?;
             if meta.get("node_type").and_then(|v| v.as_str()) == Some("group") {
-                continue; // nested group — design assumes flat store; skip silently
+                collect_array_names_local(root, &child_path, names)?;
+                continue;
             }
-            if let Some(name) = child_path.file_name().and_then(|n| n.to_str()) {
-                names.push(name.to_string());
-            }
+            names.push(relative_array_path(root, &child_path)?);
             continue;
         }
 
         // Zarr v2: .zarray present.
         if child_path.join(".zarray").exists() {
-            if let Some(name) = child_path.file_name().and_then(|n| n.to_str()) {
-                names.push(name.to_string());
-            }
+            names.push(relative_array_path(root, &child_path)?);
+            continue;
         }
+
+        // A v2 group has .zgroup; intermediate containers may have no metadata.
+        collect_array_names_local(root, &child_path, names)?;
     }
-    names.sort();
-    Ok(names)
+    Ok(())
+}
+
+fn relative_array_path(
+    root: &Path,
+    array_path: &Path,
+) -> Result<String, Box<dyn std::error::Error>> {
+    Ok(array_path
+        .strip_prefix(root)?
+        .components()
+        .map(|part| part.as_os_str().to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/"))
 }
 
 fn list_array_names_remote(store: &ZarrStore) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -136,17 +159,13 @@ fn list_array_names_remote(store: &ZarrStore) -> Result<Vec<String>, Box<dyn std
     let group = Group::open(store.clone(), "/")?;
     let consolidated = group.consolidated_metadata().ok_or(
         "remote Zarr store has no consolidated metadata in zarr.json; \
-         re-write the store with consolidated=True (xarray: zarr.consolidate_metadata(store))"
+         re-write the store with consolidated=True (xarray: zarr.consolidate_metadata(store))",
     )?;
     let mut names: Vec<String> = consolidated
         .metadata
         .iter()
         .filter_map(|(path, meta)| {
-            // Only top-level arrays (no '/' in path after stripping leading '/').
             let name = path.trim_start_matches('/');
-            if name.contains('/') {
-                return None;
-            }
             if matches!(meta, NodeMetadata::Array(_)) {
                 Some(name.to_string())
             } else {
@@ -159,12 +178,95 @@ fn list_array_names_remote(store: &ZarrStore) -> Result<Vec<String>, Box<dyn std
 }
 
 /// Open one array by name from the store.
-pub fn open_array(
-    store: &ZarrStore,
-    name: &str,
-) -> Result<ZarrArray, Box<dyn std::error::Error>> {
+pub fn open_array(store: &ZarrStore, name: &str) -> Result<ZarrArray, Box<dyn std::error::Error>> {
     let path = format!("/{name}");
     Ok(Array::open(store.clone(), &path)?)
+}
+
+/// Resolve and validate a user-provided store-relative array path.
+pub fn select_array_name(
+    array_names: &[String],
+    requested: &str,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let normalized = requested.trim().trim_matches('/');
+    array_names
+        .iter()
+        .find(|name| name.as_str() == normalized)
+        .cloned()
+        .ok_or_else(|| {
+            format!(
+                "array '{requested}' not found; available arrays: {:?}",
+                array_names
+            )
+            .into()
+        })
+}
+
+/// Build a one-array dimension group for `read_zarr(..., array_path='path')`.
+///
+/// Coordinate arrays are resolved from the selected array's sibling group first,
+/// then from the store root. OME-Zarr arrays normally have no coordinate arrays,
+/// so their named dimensions are synthesized as integer indices.
+pub fn dim_group_for_array(
+    store: &ZarrStore,
+    array_names: &[String],
+    array_name: &str,
+) -> Result<DimGroup, Box<dyn std::error::Error>> {
+    let arr = open_array(store, array_name)?;
+    let dims = dimension_names(&arr, array_name)?;
+    let shape = arr.shape().to_vec();
+    let first_chunk = vec![0u64; shape.len()];
+    let chunk_shape = arr
+        .chunk_shape(&first_chunk)?
+        .iter()
+        .map(|x| x.get())
+        .collect();
+    let coord_var_names = dims
+        .iter()
+        .filter_map(|dim| find_coord_array_path(store, array_names, array_name, dim))
+        .collect();
+
+    Ok(DimGroup {
+        dims,
+        shape,
+        chunk_shape,
+        data_var_names: vec![array_name.to_string()],
+        coord_var_names,
+    })
+}
+
+fn parent_path(name: &str) -> &str {
+    name.rsplit_once('/')
+        .map(|(parent, _)| parent)
+        .unwrap_or("")
+}
+
+fn basename(name: &str) -> &str {
+    name.rsplit('/').next().unwrap_or(name)
+}
+
+fn find_coord_array_path(
+    store: &ZarrStore,
+    array_names: &[String],
+    data_var_name: &str,
+    dim: &str,
+) -> Option<String> {
+    let parent = parent_path(data_var_name);
+    let sibling = if parent.is_empty() {
+        dim.to_string()
+    } else {
+        format!("{parent}/{dim}")
+    };
+
+    let match_path = [sibling.as_str(), dim].into_iter().find_map(|candidate| {
+        if !array_names.iter().any(|name| name == candidate) {
+            return None;
+        }
+        let arr = open_array(store, candidate).ok()?;
+        let dims = dimension_names(&arr, candidate).ok()?;
+        (arr.shape().len() == 1 && dims.as_slice() == [dim]).then(|| candidate.to_string())
+    });
+    match_path
 }
 
 /// Resolve dimension names for an array.
@@ -199,10 +301,7 @@ pub fn dimension_names(
 
 /// Parse `ZarrDtype` from the zarrs DataType.
 /// `DataType::to_string()` may emit "v3_name / v2_name"; we use the v3 name (first token).
-pub fn parse_dtype(
-    array: &ZarrArray,
-    name: &str,
-) -> Result<ZarrDtype, Box<dyn std::error::Error>> {
+pub fn parse_dtype(array: &ZarrArray, name: &str) -> Result<ZarrDtype, Box<dyn std::error::Error>> {
     let full = array.data_type().to_string();
     let type_str = full.split(" / ").next().unwrap_or(&full);
     ZarrDtype::from_str(type_str)
@@ -243,8 +342,12 @@ fn parse_sentinel(
     dtype: &ZarrDtype,
     attrs: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<FillSentinel> {
-    let fill = attrs.get("_FillValue").and_then(|v| parse_fill_value(dtype, v));
-    let missing = attrs.get("missing_value").and_then(|v| parse_fill_value(dtype, v));
+    let fill = attrs
+        .get("_FillValue")
+        .and_then(|v| parse_fill_value(dtype, v));
+    let missing = attrs
+        .get("missing_value")
+        .and_then(|v| parse_fill_value(dtype, v));
     // xarray encodes _FillValue=NaN when it has already replaced fill values with NaN
     // in memory. For stores that use missing_value as the actual on-disk sentinel,
     // NaN in _FillValue is not the sentinel we need to mask; prefer missing_value.
@@ -328,10 +431,7 @@ fn parse_zarr_fill_sentinel(array: &ZarrArray, dtype: &ZarrDtype) -> Option<Fill
 
 /// Collect the set of non-dimension coord names from all `coordinates` attrs
 /// across all arrays. These must be excluded from dim-group classification.
-pub fn collect_auxiliary_coords(
-    store: &ZarrStore,
-    array_names: &[String],
-) -> HashSet<String> {
+pub fn collect_auxiliary_coords(store: &ZarrStore, array_names: &[String]) -> HashSet<String> {
     let mut aux = HashSet::new();
     for name in array_names {
         if let Ok(arr) = open_array(store, name) {
@@ -425,10 +525,10 @@ pub fn infer_dim_groups(
             continue;
         }
 
-        // Dim-coord heuristic: 1-D array whose sole dim shares its name.
+        // Dim-coord heuristic: 1-D array whose sole dim shares its basename.
         if shape.len() == 1 {
             if let Ok(dims) = dimension_names(&arr, name) {
-                if dims.len() == 1 && dims[0] == *name {
+                if dims.len() == 1 && dims[0] == basename(name) {
                     coord_names.insert(name.clone());
                     continue;
                 }
@@ -457,8 +557,7 @@ pub fn infer_dim_groups(
         // Collect coord names that belong to this dim group (dims that have matching coord arrays).
         let group_coord_names: Vec<String> = dims
             .iter()
-            .filter(|d| coord_names.contains(*d))
-            .cloned()
+            .filter_map(|dim| find_coord_array_path(store, array_names, var_name, dim))
             .collect();
 
         let entry = groups.entry(dims.clone()).or_insert_with(|| DimGroup {
@@ -471,14 +570,14 @@ pub fn infer_dim_groups(
         // Validate shape and chunk shape consistency within the dim group.
         if entry.shape != shape {
             return Err(format!(
-                "array shape mismatch in dim group {:?}: existing {:?} vs '{var_name}' {:?}",
+                "array shape mismatch in dim group {:?}: existing {:?} vs '{var_name}' {:?}; use array_path= to select one array",
                 entry.dims, entry.shape, shape
             )
             .into());
         }
         if entry.chunk_shape != chunk_shape {
             return Err(format!(
-                "chunk shape mismatch in dim group {:?}: existing {:?} vs '{var_name}' {:?}",
+                "chunk shape mismatch in dim group {:?}: existing {:?} vs '{var_name}' {:?}; use array_path= to select one array",
                 entry.dims, entry.chunk_shape, chunk_shape
             )
             .into());
@@ -490,6 +589,77 @@ pub fn infer_dim_groups(
     dim_groups.sort_by(|a, b| a.dims.cmp(&b.dims));
 
     Ok((dim_groups, coord_names))
+}
+
+/// Discover dimension groups for metadata inspection without requiring every
+/// array that shares dimension names to also share shape and chunk layout.
+///
+/// Multiscale OME-Zarr levels deliberately reuse axis names at different
+/// resolutions, so `read_zarr_groups` groups by `(dims, shape, chunk_shape)`.
+/// The stricter [`infer_dim_groups`] remains in the scan path because one scan
+/// can only align variables with identical shapes and chunk grids.
+pub fn discover_dim_groups(
+    store: &ZarrStore,
+    array_names: &[String],
+) -> Result<Vec<DimGroup>, Box<dyn std::error::Error>> {
+    let aux_coords = collect_auxiliary_coords(store, array_names);
+    let bounds_vars = collect_bounds_vars(store, array_names, &aux_coords);
+    let mut coord_names = HashSet::new();
+
+    for name in array_names {
+        if bounds_vars.contains(name) || aux_coords.contains(name) {
+            continue;
+        }
+        let arr = open_array(store, name)?;
+        if arr.shape().len() == 1 {
+            if let Ok(dims) = dimension_names(&arr, name) {
+                if dims.len() == 1 && dims[0] == basename(name) {
+                    coord_names.insert(name.clone());
+                }
+            }
+        }
+    }
+
+    type GroupKey = (Vec<String>, Vec<u64>, Vec<u64>);
+    let mut groups: HashMap<GroupKey, DimGroup> = HashMap::new();
+    for name in array_names {
+        if bounds_vars.contains(name) || aux_coords.contains(name) || coord_names.contains(name) {
+            continue;
+        }
+        let arr = open_array(store, name)?;
+        let shape = arr.shape().to_vec();
+        if shape.is_empty() {
+            continue;
+        }
+        let dims = dimension_names(&arr, name)?;
+        let chunk_shape = arr
+            .chunk_shape(&vec![0u64; shape.len()])?
+            .iter()
+            .map(|x| x.get())
+            .collect::<Vec<_>>();
+        let coord_var_names = dims
+            .iter()
+            .filter_map(|dim| find_coord_array_path(store, array_names, name, dim))
+            .collect::<Vec<_>>();
+        let key = (dims.clone(), shape.clone(), chunk_shape.clone());
+        let group = groups.entry(key).or_insert_with(|| DimGroup {
+            dims,
+            shape,
+            chunk_shape,
+            data_var_names: Vec::new(),
+            coord_var_names,
+        });
+        group.data_var_names.push(name.clone());
+    }
+
+    let mut dim_groups = groups.into_values().collect::<Vec<_>>();
+    dim_groups.sort_by(|a, b| {
+        a.dims
+            .cmp(&b.dims)
+            .then_with(|| a.shape.cmp(&b.shape))
+            .then_with(|| a.data_var_names.cmp(&b.data_var_names))
+    });
+    Ok(dim_groups)
 }
 
 /// Pre-load a coordinate array's raw bytes at bind time.
@@ -509,7 +679,9 @@ pub fn load_coord_array(
     // decoded bytes; zarrs allocates a fresh Vec<u8> satisfying the 'static bound.
     let subset = arr.subset_all();
     let array_bytes = arr.retrieve_array_subset::<zarrs::array::ArrayBytes<'static>>(&subset)?;
-    let raw = array_bytes.into_fixed().map_err(|_| "coord array has variable-length dtype")?;
+    let raw = array_bytes
+        .into_fixed()
+        .map_err(|_| "coord array has variable-length dtype")?;
     let bytes: Vec<u8> = raw.into_owned();
     debug_assert_eq!(
         bytes.len(),
@@ -532,9 +704,7 @@ pub fn build_work_units(group: &DimGroup) -> Vec<WorkUnit> {
         .dims
         .iter()
         .enumerate()
-        .map(|(i, _)| {
-            group.shape[i].div_ceil(group.chunk_shape[i])
-        })
+        .map(|(i, _)| group.shape[i].div_ceil(group.chunk_shape[i]))
         .collect();
 
     // Total number of chunks.

--- a/test/sql/bioimage_ome_zarr.test
+++ b/test/sql/bioimage_ome_zarr.test
@@ -1,0 +1,97 @@
+# name: test/sql/bioimage_ome_zarr.test
+# description: xarray-style SQL queries over an OME-Zarr bioimage
+# group: [duckdb_zarr]
+
+require duckdb_zarr
+
+load duckdb_zarr
+
+# The fixture is written by xarray with named c/y/x dimensions and OME-Zarr
+# multiscales metadata. The array is named "0", following the conventional
+# path for the highest-resolution level of a multiscale bioimage.
+
+query I
+SELECT COUNT(*)
+FROM read_zarr(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = '0'
+);
+----
+24
+
+# Named xarray dimensions make channel and spatial queries self-describing.
+query II rowsort
+SELECT c, SUM("0")
+FROM read_zarr(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = '0'
+)
+GROUP BY c;
+----
+0	78
+1	1278
+
+# Query a spatial region from the DNA channel using image-axis names.
+query II
+SELECT COUNT(*), SUM("0")
+FROM read_zarr(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = '0'
+)
+WHERE c = 0 AND y < 2 AND x < 2;
+----
+4	14
+
+# The OME-Zarr array is discoverable as one c/y/x dimension group.
+query II rowsort
+SELECT dims, data_vars
+FROM read_zarr_groups('test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr');
+----
+["c","y","x"]	["0"]
+["y","x"]	["labels/nuclei/0"]
+
+# Recursive metadata discovery reports arrays inside the labels hierarchy.
+query TT rowsort
+SELECT name, role
+FROM read_zarr_metadata('test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr');
+----
+0	data
+labels/nuclei/0	data
+
+# array_path= selects a nested image-label array while retaining named image axes.
+query III
+SELECT COUNT(*), COUNT(*) FILTER (WHERE "labels/nuclei/0" > 0), SUM("labels/nuclei/0")
+FROM read_zarr(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = 'labels/nuclei/0'
+);
+----
+12	6	9
+
+# Metadata and group inspection accept the same store-relative selector.
+query T
+SELECT shape
+FROM read_zarr_metadata(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    "array" = '/labels/nuclei/0/'
+);
+----
+[3,4]
+
+query TT
+SELECT dims, data_vars
+FROM read_zarr_groups(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = 'labels/nuclei/0'
+);
+----
+["y","x"]	["labels/nuclei/0"]
+
+statement error
+SELECT *
+FROM read_zarr(
+    'test/fixtures/bioimage/ome_zarr/synthetic_multichannel.ome.zarr',
+    array_path = 'labels/missing/0'
+);
+----
+array 'labels/missing/0' not found


### PR DESCRIPTION
Adds recursive array discovery and `array_path=` selection for multiscale and nested OME-Zarr data. Includes xarray-based bioimage tests, a concise OME-Zarr guide, and documentation of currently tested scientific domains.

Closes #15 