### PR TITLE
Add and apply rustfmt and clippy for ci

### DIFF
--- a/.github/workflows/rust-quality.yml
+++ b/.github/workflows/rust-quality.yml
@@ -1,0 +1,26 @@
+name: Rust quality
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}
+  cancel-in-progress: true
+
+jobs:
+  prek:
+    name: prek
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+      - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: local
+    hooks:
+      - id: rustfmt
+        name: rustfmt
+        entry: make fmt
+        language: system
+        files: \.rs$
+        pass_filenames: false
+      - id: clippy
+        name: Clippy
+        entry: make clippy
+        language: system
+        files: (^Cargo\.(toml|lock)$|\.rs$)
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,13 +25,26 @@ make
 
 # Run tests
 make test
+
+# Format Rust code
+make fmt
+
+# Check formatting and run Clippy
+make lint
+
+# Install the Git hooks
+uv run prek install
+
+# Run the hooks against the whole repository
+uv run prek run --all-files
 ```
 
 Tests live in `test/sql/` as DuckDB `.test` files. New functionality should include corresponding tests.
 
 ## Code style
 
-- Rust: `cargo fmt` and `cargo clippy` must pass before submission.
+- Rust: `make lint` must pass before submission.
+- Git hooks: `prek` applies rustfmt and runs Clippy before each commit.
 - Commit messages: short imperative subject line, blank line, then details if needed.
 
 ## Submitting a pull request

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean_all generate_fixtures
+.PHONY: clean clean_all clippy fmt fmt-check generate_fixtures lint
 
 PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -38,6 +38,17 @@ release: build_extension_library_release build_extension_with_metadata_release
 test: test_debug
 test_debug: generate_fixtures test_extension_debug
 test_release: generate_fixtures test_extension_release
+
+fmt:
+	cargo fmt --all
+
+fmt-check:
+	cargo fmt --all -- --check
+
+clippy:
+	cargo clippy --lib --all-features -- -D warnings
+
+lint: fmt-check clippy
 
 generate_fixtures:
 	@if command -v uv >/dev/null 2>&1; then \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
+    "prek>=0.4.5",
     "pytest",
 ]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,7 @@ unsafe fn duckdb_zarr_init_c_api_internal(
             return Ok(false);
         }
 
-        let get_database = (*access)
-            .get_database
-            .ok_or("get_database is null")?;
+        let get_database = (*access).get_database.ok_or("get_database is null")?;
         let db_ptr = get_database(info);
         if db_ptr.is_null() {
             return Ok(false);

--- a/src/read_zarr.rs
+++ b/src/read_zarr.rs
@@ -94,14 +94,12 @@ impl VTab for ReadZarrVTab {
         }
 
         let group = match requested_dims {
-            Some(ref dims) => {
-                dim_groups.iter().find(|g| g.dims == *dims).ok_or_else(|| {
-                    format!(
-                        "'{store_path}': no dimension group matches dims={dims:?}; available: {:?}",
-                        dim_groups.iter().map(|g| &g.dims).collect::<Vec<_>>()
-                    )
-                })?
-            }
+            Some(ref dims) => dim_groups.iter().find(|g| g.dims == *dims).ok_or_else(|| {
+                format!(
+                    "'{store_path}': no dimension group matches dims={dims:?}; available: {:?}",
+                    dim_groups.iter().map(|g| &g.dims).collect::<Vec<_>>()
+                )
+            })?,
             None => {
                 if dim_groups.len() > 1 {
                     return Err(format!(
@@ -128,7 +126,8 @@ impl VTab for ReadZarrVTab {
         // DuckDB guarantees output.flat_vector(i) in scan() corresponds to
         // get_column_indices()[i] from init(). Do NOT sort — sorting destroys
         // the positional relationship and scrambles output in JOIN context.
-        let projected_cols: HashMap<usize, usize> = init.get_column_indices()
+        let projected_cols: HashMap<usize, usize> = init
+            .get_column_indices()
             .into_iter()
             .enumerate()
             .map(|(out_idx, col_idx)| (col_idx as usize, out_idx))
@@ -236,7 +235,11 @@ fn parse_dims_param(s: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> 
         let arr: Vec<String> = serde_json::from_str(trimmed)?;
         Ok(arr)
     } else {
-        Ok(trimmed.split(',').map(|d| d.trim().to_string()).filter(|d| !d.is_empty()).collect())
+        Ok(trimmed
+            .split(',')
+            .map(|d| d.trim().to_string())
+            .filter(|d| !d.is_empty())
+            .collect())
     }
 }
 
@@ -296,12 +299,15 @@ fn decode_work_unit(
         if !projected.contains_key(&col_idx) {
             continue; // skip decompression for non-projected data vars
         }
-        let arr = bind.arrays.get(&col.name)
+        let arr = bind
+            .arrays
+            .get(&col.name)
             .ok_or_else(|| format!("array '{}' not found in bind cache", col.name))?;
         // ArrayBytes<'static>: zarrs convention for requesting owned decoded bytes.
         // retrieve_chunk fills missing (implicit) chunks with fill_value automatically.
         let raw = arr.retrieve_chunk::<zarrs::array::ArrayBytes<'static>>(&wu.chunk_indices)?;
-        let bytes: Vec<u8> = raw.into_fixed()
+        let bytes: Vec<u8> = raw
+            .into_fixed()
             .map_err(|_| format!("variable-length dtype not supported for '{}'", col.name))?
             .into_owned();
         chunk_bytes.insert(col.name.clone(), bytes);
@@ -428,7 +434,10 @@ fn fill_chunk_slice(
                         dst,
                     );
                 } else {
-                    unreachable!("projected data variable '{}' missing from chunk_bytes", col_def.name);
+                    unreachable!(
+                        "projected data variable '{}' missing from chunk_bytes",
+                        col_def.name
+                    );
                 }
             }
         }
@@ -455,7 +464,10 @@ fn fill_data_element(
                 vector, bytes, dtype, sentinel, flat_row, elem_size, dst,
             );
         }
-        ColumnEncoding::PackedInt { scale_factor, add_offset } => {
+        ColumnEncoding::PackedInt {
+            scale_factor,
+            add_offset,
+        } => {
             let src = flat_row * elem_size;
             let raw = crate::zarr_reader::scan::read_int_as_i64_pub(bytes, dtype, src);
             let is_null = match sentinel {

--- a/src/read_zarr_groups.rs
+++ b/src/read_zarr_groups.rs
@@ -3,7 +3,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use duckdb::core::LogicalTypeId;
 use duckdb::vtab::{BindInfo, InitInfo, TableFunctionInfo, VTab};
 
-use crate::zarr_reader::meta::{extract_file_system, infer_dim_groups, list_array_names, open_store};
+use crate::zarr_reader::meta::{
+    extract_file_system, infer_dim_groups, list_array_names, open_store,
+};
 
 #[derive(Debug, Clone)]
 struct GroupRow {

--- a/src/read_zarr_metadata.rs
+++ b/src/read_zarr_metadata.rs
@@ -12,12 +12,12 @@ use crate::zarr_reader::meta::{
 #[derive(Debug, Clone)]
 struct MetaRow {
     name: String,
-    dims: String,       // JSON array string e.g. '["lat","lon"]'
+    dims: String, // JSON array string e.g. '["lat","lon"]'
     dtype: String,
-    shape: String,      // JSON array string e.g. '[4,6]'
+    shape: String, // JSON array string e.g. '[4,6]'
     chunk_shape: String,
-    attrs: String,      // full attrs as JSON string
-    role: String,       // "coord" | "data" | "aux_coord" | "bounds" | "scalar" | "unknown"
+    attrs: String, // full attrs as JSON string
+    role: String,  // "coord" | "data" | "aux_coord" | "bounds" | "scalar" | "unknown"
 }
 
 pub struct ReadZarrMetaBind {
@@ -82,10 +82,7 @@ impl VTab for ReadZarrMetaVTab {
                 "scalar"
             } else if aux_coords.contains(name) {
                 "aux_coord"
-            } else if shape.len() == 1
-                && dims.len() == 1
-                && dims[0] == *name
-            {
+            } else if shape.len() == 1 && dims.len() == 1 && dims[0] == *name {
                 "coord"
             } else {
                 "data"

--- a/src/zarr_reader/duckdb_store.rs
+++ b/src/zarr_reader/duckdb_store.rs
@@ -1,8 +1,8 @@
 use std::ffi::CString;
 
 use zarrs::storage::{
-    byte_range::ByteRangeIterator, Bytes, MaybeBytesIterator, ReadableStorageTraits,
-    StorageError, StoreKey,
+    byte_range::ByteRangeIterator, Bytes, MaybeBytesIterator, ReadableStorageTraits, StorageError,
+    StoreKey,
 };
 
 use duckdb::ffi::{
@@ -47,10 +47,7 @@ impl DuckDbStore {
     }
 
     /// Opens a file for reading. Returns `None` if the key does not exist.
-    unsafe fn open_read(
-        &self,
-        key: &StoreKey,
-    ) -> Result<Option<duckdb_file_handle>, StorageError> {
+    unsafe fn open_read(&self, key: &StoreKey) -> Result<Option<duckdb_file_handle>, StorageError> {
         let path_cstr = self.key_path(key)?;
         let opts = duckdb_create_file_open_options();
         duckdb_file_open_options_set_flag(opts, duckdb_file_flag_DUCKDB_FILE_FLAG_READ, true);
@@ -93,9 +90,8 @@ impl ReadableStorageTraits for DuckDbStore {
                 continue;
             }
             let mut buf = vec![0u8; length as usize];
-            let bytes_read = unsafe {
-                duckdb_file_handle_read(handle, buf.as_mut_ptr().cast(), length as i64)
-            };
+            let bytes_read =
+                unsafe { duckdb_file_handle_read(handle, buf.as_mut_ptr().cast(), length as i64) };
             if bytes_read < 0 || bytes_read as u64 != length {
                 results.push(Err(StorageError::Other(format!(
                     "read of {length} bytes at offset {offset} returned {bytes_read}"

--- a/src/zarr_reader/meta.rs
+++ b/src/zarr_reader/meta.rs
@@ -67,7 +67,8 @@ pub fn open_store(
             unsafe { duckdb_destroy_file_system(&mut fs) };
         }
         Ok(Arc::new(zarrs_http::HTTPStore::new(path)?))
-    } else if lower.starts_with("s3://") || lower.starts_with("gs://") || lower.starts_with("az://") {
+    } else if lower.starts_with("s3://") || lower.starts_with("gs://") || lower.starts_with("az://")
+    {
         let fs = file_system.ok_or(
             "remote store requires a DuckDB FileSystem handle (call from a table function bind)",
         )?;
@@ -136,7 +137,7 @@ fn list_array_names_remote(store: &ZarrStore) -> Result<Vec<String>, Box<dyn std
     let group = Group::open(store.clone(), "/")?;
     let consolidated = group.consolidated_metadata().ok_or(
         "remote Zarr store has no consolidated metadata in zarr.json; \
-         re-write the store with consolidated=True (xarray: zarr.consolidate_metadata(store))"
+         re-write the store with consolidated=True (xarray: zarr.consolidate_metadata(store))",
     )?;
     let mut names: Vec<String> = consolidated
         .metadata
@@ -159,10 +160,7 @@ fn list_array_names_remote(store: &ZarrStore) -> Result<Vec<String>, Box<dyn std
 }
 
 /// Open one array by name from the store.
-pub fn open_array(
-    store: &ZarrStore,
-    name: &str,
-) -> Result<ZarrArray, Box<dyn std::error::Error>> {
+pub fn open_array(store: &ZarrStore, name: &str) -> Result<ZarrArray, Box<dyn std::error::Error>> {
     let path = format!("/{name}");
     Ok(Array::open(store.clone(), &path)?)
 }
@@ -199,10 +197,7 @@ pub fn dimension_names(
 
 /// Parse `ZarrDtype` from the zarrs DataType.
 /// `DataType::to_string()` may emit "v3_name / v2_name"; we use the v3 name (first token).
-pub fn parse_dtype(
-    array: &ZarrArray,
-    name: &str,
-) -> Result<ZarrDtype, Box<dyn std::error::Error>> {
+pub fn parse_dtype(array: &ZarrArray, name: &str) -> Result<ZarrDtype, Box<dyn std::error::Error>> {
     let full = array.data_type().to_string();
     let type_str = full.split(" / ").next().unwrap_or(&full);
     ZarrDtype::from_str(type_str)
@@ -243,8 +238,12 @@ fn parse_sentinel(
     dtype: &ZarrDtype,
     attrs: &serde_json::Map<String, serde_json::Value>,
 ) -> Option<FillSentinel> {
-    let fill = attrs.get("_FillValue").and_then(|v| parse_fill_value(dtype, v));
-    let missing = attrs.get("missing_value").and_then(|v| parse_fill_value(dtype, v));
+    let fill = attrs
+        .get("_FillValue")
+        .and_then(|v| parse_fill_value(dtype, v));
+    let missing = attrs
+        .get("missing_value")
+        .and_then(|v| parse_fill_value(dtype, v));
     // xarray encodes _FillValue=NaN when it has already replaced fill values with NaN
     // in memory. For stores that use missing_value as the actual on-disk sentinel,
     // NaN in _FillValue is not the sentinel we need to mask; prefer missing_value.
@@ -328,10 +327,7 @@ fn parse_zarr_fill_sentinel(array: &ZarrArray, dtype: &ZarrDtype) -> Option<Fill
 
 /// Collect the set of non-dimension coord names from all `coordinates` attrs
 /// across all arrays. These must be excluded from dim-group classification.
-pub fn collect_auxiliary_coords(
-    store: &ZarrStore,
-    array_names: &[String],
-) -> HashSet<String> {
+pub fn collect_auxiliary_coords(store: &ZarrStore, array_names: &[String]) -> HashSet<String> {
     let mut aux = HashSet::new();
     for name in array_names {
         if let Ok(arr) = open_array(store, name) {
@@ -509,7 +505,9 @@ pub fn load_coord_array(
     // decoded bytes; zarrs allocates a fresh Vec<u8> satisfying the 'static bound.
     let subset = arr.subset_all();
     let array_bytes = arr.retrieve_array_subset::<zarrs::array::ArrayBytes<'static>>(&subset)?;
-    let raw = array_bytes.into_fixed().map_err(|_| "coord array has variable-length dtype")?;
+    let raw = array_bytes
+        .into_fixed()
+        .map_err(|_| "coord array has variable-length dtype")?;
     let bytes: Vec<u8> = raw.into_owned();
     debug_assert_eq!(
         bytes.len(),
@@ -532,9 +530,7 @@ pub fn build_work_units(group: &DimGroup) -> Vec<WorkUnit> {
         .dims
         .iter()
         .enumerate()
-        .map(|(i, _)| {
-            group.shape[i].div_ceil(group.chunk_shape[i])
-        })
+        .map(|(i, _)| group.shape[i].div_ceil(group.chunk_shape[i]))
         .collect();
 
     // Total number of chunks.

--- a/src/zarr_reader/scan.rs
+++ b/src/zarr_reader/scan.rs
@@ -91,11 +91,11 @@ macro_rules! impl_null_check_int {
     };
 }
 
-impl_null_check_int!(i8,  Int,  i64);
-impl_null_check_int!(i16, Int,  i64);
-impl_null_check_int!(i32, Int,  i64);
-impl_null_check_int!(i64, Int,  i64);
-impl_null_check_int!(u8,  UInt, u64);
+impl_null_check_int!(i8, Int, i64);
+impl_null_check_int!(i16, Int, i64);
+impl_null_check_int!(i32, Int, i64);
+impl_null_check_int!(i64, Int, i64);
+impl_null_check_int!(u8, UInt, u64);
 impl_null_check_int!(u16, UInt, u64);
 impl_null_check_int!(u32, UInt, u64);
 impl_null_check_int!(u64, UInt, u64);
@@ -108,7 +108,11 @@ impl NullCheck for f32 {
             // widths match, then use exact equality — not an epsilon band, which would
             // incorrectly mask non-sentinel values near zero.
             Some(FillSentinel::Float(v)) => {
-                if v.is_nan() { self.is_nan() } else { (self as f64) == *v }
+                if v.is_nan() {
+                    self.is_nan()
+                } else {
+                    (self as f64) == *v
+                }
             }
             _ => false,
         }
@@ -119,7 +123,11 @@ impl NullCheck for f64 {
     fn check_fill(self, s: &Option<FillSentinel>) -> bool {
         match s {
             Some(FillSentinel::Float(v)) => {
-                if v.is_nan() { self.is_nan() } else { self == *v }
+                if v.is_nan() {
+                    self.is_nan()
+                } else {
+                    self == *v
+                }
             }
             _ => false,
         }

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "prek" },
     { name = "pytest" },
 ]
 
@@ -202,7 +203,10 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest" }]
+dev = [
+    { name = "prek", specifier = ">=0.4.5" },
+    { name = "pytest" },
+]
 
 [[package]]
 name = "google-crc32c"
@@ -526,6 +530,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
+]
+
+[[package]]
+name = "prek"
+version = "0.4.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/65/23866f43521d31173879aa74bb3a2df50ab7f3f74cdb4eaa31b8f446c7ca/prek-0.4.5.tar.gz", hash = "sha256:2be7bcf839de19a0144ed5a5aadf73bc5899cf6823bb1c58cf1d45ae389c201a", size = 482566, upload-time = "2026-06-15T11:36:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/cb/a9eedf9a35ca6ec72f12af2b4392d7f757bb24863b7b7af4523f939cf3fa/prek-0.4.5-py3-none-linux_armv6l.whl", hash = "sha256:f7517774c72b001573520dc7111156779fd3e5b4452c11f09ff53c71a067e835", size = 5618105, upload-time = "2026-06-15T11:36:21.998Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a7/c96c06f17db7da0a57be2be4c229aa00b525bca8001c9c765663b339cbb7/prek-0.4.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aca9fa995536036a0171bcf7a4db96dc0a14f480054eda1d7d1c2e7739650993", size = 5972998, upload-time = "2026-06-15T11:36:41.12Z" },
+    { url = "https://files.pythonhosted.org/packages/28/f1/721695355cdaa44be6f091e3a77fb9c72ed60289520f78b2f8c9a7197bdd/prek-0.4.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:66877ff21ae9d548f0f7e56fab8e65f1500a74a810e7749188c3f35a4a1b911b", size = 5525098, upload-time = "2026-06-15T11:36:30.127Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/1b/a334e1bb5361b49adf52b5ac7b6532018940f9f0f253437e8f43c3c1f7f3/prek-0.4.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:50697089a86a78d16f087c1912a2f3bc2bea82319a220fac52cc8e3ec9fc0426", size = 5793732, upload-time = "2026-06-15T11:36:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/28/8c/aff94d276e91207a87cedff7cfefdd4aca20444137cca77bf53fffebe77a/prek-0.4.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:590427a42a3c1e5064487a0dc91167ae0c8a52168e77f574758ef9b138fcfd61", size = 5521719, upload-time = "2026-06-15T11:36:39.383Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/73/cfb0c5c909442050a8357e26233f7e511ba8e0d2f4b0bdc460065d62beb6/prek-0.4.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1fd98b986767dafdb6b4305b563ee5a3a8f13bd3c78b98d708626815ea9f147f", size = 5922623, upload-time = "2026-06-15T11:36:18.063Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/ad/ff9d26551ba80d190bd08c6341176a5d56d4e6de9c2ebf077793d4adbb78/prek-0.4.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fccd11613ae92619d1ecda0ab3359ceebeb38898909ec84a8d383733d12158cc", size = 6722071, upload-time = "2026-06-15T11:36:43.086Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/11d1dfd66c919953fe89ae2fdedd4f413ee923883043816d35982177bb75/prek-0.4.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14109d37b33e5529db41a3539d4f8f72d295f6eeddede3964994d898b8cec05c", size = 6176454, upload-time = "2026-06-15T11:36:33.803Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d4/9749f25c2e0ee5225f812457b888acef301e0ccce64bebcda2ac1d04abee/prek-0.4.5-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:40d262418105b2ede9836593a1927fc927cc8093c432e998640964102196996e", size = 5791133, upload-time = "2026-06-15T11:36:23.891Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/72/5e0344bab1eacf813a5b1b082cb4c6253930096166dad51c1cccee0a4f83/prek-0.4.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a586d14c3b852fdee1c3dcd0b9cb0915db9f9d054334b854fd9470bf68edf129", size = 5658098, upload-time = "2026-06-15T11:36:44.862Z" },
+    { url = "https://files.pythonhosted.org/packages/be/a5/1f406e0362dd0f18ba09a562d50d7c04a70ac05d350b1ab6fba36ca3e9f0/prek-0.4.5-py3-none-musllinux_1_1_armv7l.whl", hash = "sha256:a8ed0d28f3e7790e4402a9324c386509066df6e67cc587f7406f9a245b97b7e8", size = 5498634, upload-time = "2026-06-15T11:36:31.828Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/df/b0cbf0fa527330188390b7b6c8d279cd5e509923262d0a6c5cc44bbdf103/prek-0.4.5-py3-none-musllinux_1_1_i686.whl", hash = "sha256:86f76bd3d2ecf6fd9034d75c62ff4c786eb11d0dd0a1f79bbb4343b023e12769", size = 5784840, upload-time = "2026-06-15T11:36:37.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/d7/977ee3c622c906677dd94187a00392ce2dd76035486b3a3b1b5a5267dd34/prek-0.4.5-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:e491a1a4641d91d8b03dcce5588397e76d2a5b432c9b0a6c70475972b4512ab4", size = 6300384, upload-time = "2026-06-15T11:36:27.602Z" },
+    { url = "https://files.pythonhosted.org/packages/79/fa/43b1d761381dc1c7eeb8f2235c66e902970d4b2bff2dec0f02836c085769/prek-0.4.5-py3-none-win32.whl", hash = "sha256:7546989b2403c96137bd79d19ebfe21facb87266cefe819db2458c3b9b23f350", size = 5287935, upload-time = "2026-06-15T11:36:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/fe/59b5eb3124f5a4cc255a93857b9ab42402635b273f157e91de23bfa40e8f/prek-0.4.5-py3-none-win_amd64.whl", hash = "sha256:8b2ac9227504371d97338215b344184cb0b31ca94113515a3a90c509c6c5a707", size = 5682560, upload-time = "2026-06-15T11:36:25.865Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0e/589ff0eab9034909b1ec8654ee03483797305fb743b3554ce6140d82da9d/prek-0.4.5-py3-none-win_arm64.whl", hash = "sha256:646a86a1a082dbd99fed96314b1064f5644bb34c1f4037a63547a18e2160fb86", size = 5509019, upload-time = "2026-06-15T11:36:46.595Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR adds and applies rustfmt and clippy as linting tools used within CI. I thought it'd be helpful to have these implemented as both local dev tools through pre-commit and also tested through their own CI check based on the same.