### PR TITLE
Readying for community extension releases

### DIFF
--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -1,0 +1,45 @@
+name: Community Extension Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Release tag or 40-character commit hash to publish
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  descriptor:
+    name: Render community descriptor
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_REF: ${{ github.event.release.tag_name || inputs.ref }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Render descriptor for release ref
+        run: |
+          uv run scripts/render_community_descriptor.py \
+            --ref "$RELEASE_REF" \
+            --out build/community-extensions/extensions/duckdb_zarr/description.yml
+
+      - name: Validate rendered descriptor
+        run: |
+          uv run scripts/check_release_ready.py \
+            --description-path build/community-extensions/extensions/duckdb_zarr/description.yml \
+            --strict-community-ref
+
+      - name: Upload descriptor artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: duckdb_zarr-community-extension-descriptor
+          path: build/community-extensions/extensions/duckdb_zarr/description.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,60 @@ Tests live in `test/sql/` as DuckDB `.test` files. New functionality should incl
 2. Describe *what* changed and *why* in the PR body.
 3. Be responsive to review feedback — maintainers may suggest changes before merging.
 
+## Creating a community-extension release
+
+DuckDB community-extension releases are built from `description.yml` by
+`duckdb/community-extensions`. This repository keeps the descriptor in-tree so
+release changes can be reviewed before the community PR is opened.
+
+Before publishing:
+
+```bash
+make release-check
+make test_release
+make render-community-descriptor REF=v0.1.0
+```
+
+The checked-in `description.yml` can keep `repo.ref: main`; the render command
+creates the descriptor that must be submitted to `duckdb/community-extensions`
+with `repo.ref` set to the release tag or commit hash.
+
+Release checklist:
+
+1. Confirm `Main Extension Distribution Pipeline` and `Rust quality` are green on
+   the commit to publish.
+2. Update `CHANGELOG.md`, `Cargo.toml` version, `pyproject.toml` version, and
+   `description.yml` version together.
+3. Create and publish a GitHub Release with a tag matching the project version,
+   such as `v0.1.0`.
+4. Download the descriptor artifact from the `Community Extension Release`
+   workflow.
+5. Open a PR against `duckdb/community-extensions` adding or updating
+   `extensions/duckdb_zarr/description.yml` with that artifact.
+
+See [docs/community-extension-release.md](docs/community-extension-release.md)
+for the detailed release and DuckDB-version policy.
+
+## DuckDB version policy
+
+Community extensions are built for DuckDB's latest stable release. This extension
+currently uses DuckDB's unstable C API, so the built binary only loads into the
+exact DuckDB version stamped into the extension metadata.
+
+When bumping DuckDB, update all of these in one PR:
+
+- `Makefile` `TARGET_DUCKDB_VERSION`
+- `.github/workflows/MainDistributionPipeline.yml` `duckdb_version`
+- `Cargo.toml` exact `duckdb` crate pin, plus `Cargo.lock`
+
+The crate pin follows the `duckdb-rs` encoding used by this project. For example,
+DuckDB `v1.5.4` maps to `duckdb = "=1.10504.0"`.
+
+If DuckDB's community repository is testing both latest stable and current
+DuckDB `main`, keep the published stable-compatible commit in `repo.ref` and add
+`repo.ref_next` only for a separate commit or branch that is compatible with
+DuckDB `main`.
+
 ## Code of Conduct
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md).

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: clean clean_all clippy fmt fmt-check generate_fixtures lint
+.PHONY: clean clean_all clippy fmt fmt-check generate_fixtures lint release-check render-community-descriptor
 
 PROJ_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -49,6 +49,14 @@ clippy:
 	cargo clippy --lib --all-features -- -D warnings
 
 lint: fmt-check clippy
+
+release-check:
+	python3 scripts/check_release_ready.py
+
+render-community-descriptor:
+	@test -n "$(REF)" || (echo "Usage: make render-community-descriptor REF=v0.1.0" >&2; exit 1)
+	python3 scripts/render_community_descriptor.py --ref "$(REF)" --out build/community-extensions/extensions/duckdb_zarr/description.yml
+	python3 scripts/check_release_ready.py --description-path build/community-extensions/extensions/duckdb_zarr/description.yml --strict-community-ref
 
 generate_fixtures:
 	@if command -v uv >/dev/null 2>&1; then \

--- a/description.yml
+++ b/description.yml
@@ -4,12 +4,14 @@ extension:
   version: 0.1.0
   language: Rust
   build: cargo
+  requires_toolchains: "rust;python3"
+  excluded_platforms: "wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
   license: MIT
   maintainers:
     - alxmrs
 
 repo:
-  github: alxmrs/duckdb-zarr
+  github: xqlsystems/duckdb-zarr
   # Update ref to the tagged release commit before submitting the PR to duckdb/community-extensions.
   ref: main
 
@@ -20,7 +22,7 @@ docs:
     FROM read_zarr('path/to/store.zarr')
     LIMIT 10;
   extended_description: |
-    The `duckdb_zarr` extension exposes [Zarr](https://zarr.dev/) array stores as SQL tables,
+    The duckdb-zarr extension exposes [Zarr](https://zarr.dev/) array stores as SQL tables,
     following the [xarray](https://xarray.dev/) dimension convention used by climate science,
     geospatial, and bioimaging datasets.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,11 +31,7 @@ This project is related to [xarray-sql](https://github.com/alxmrs/xarray-sql) an
 
 ### Installation
 
-**Pre-built binaries** (coming soon):
-```sql
-INSTALL zarr FROM community;
-LOAD zarr;
-```
+**Pre-built binaries**: not published yet.
 
 **Build from source** (see Development Setup below)
 

--- a/docs/community-extension-release.md
+++ b/docs/community-extension-release.md
@@ -1,0 +1,142 @@
+# Community Extension Release
+
+This project is set up to publish through DuckDB's community extension repository.
+DuckDB's process is descriptor-driven: submit a PR to `duckdb/community-extensions`
+with this repository's `description.yml`, and the community repository builds it
+with the same `extension-ci-tools` distribution workflow used here.
+
+## Local Release Gate
+
+Run the local checks before opening the community PR:
+
+```sh
+make release-check
+make test_release
+```
+
+`make release-check` verifies the release-critical metadata that is easy to drift
+in a Rust C API extension:
+
+- `Makefile` `TARGET_DUCKDB_VERSION`
+- `.github/workflows/MainDistributionPipeline.yml` `duckdb_version`
+- `Cargo.toml` exact `duckdb` crate pin
+- `description.yml` `language`, `build`, `requires_toolchains`, and excluded
+  platforms
+
+For the final community PR, also run:
+
+```sh
+python3 scripts/check_release_ready.py --strict-community-ref
+```
+
+That strict mode fails until `description.yml` `repo.ref` is an immutable release
+tag such as `v0.1.0` or a 40-character commit hash. Do not submit `ref: main`.
+
+For release automation, leave the checked-in descriptor at `ref: main` and
+render the community descriptor for a tag:
+
+```sh
+make render-community-descriptor REF=v0.1.0
+```
+
+The rendered file is written to
+`build/community-extensions/extensions/duckdb_zarr/description.yml` with
+`repo.ref` set to the release tag.
+
+## GitHub Release Automation
+
+Publishing a GitHub Release runs `.github/workflows/community-release.yml`.
+That workflow:
+
+1. Renders a community descriptor for the release tag.
+2. Validates the generated descriptor in strict mode.
+3. Uploads the descriptor as a workflow artifact.
+
+The workflow intentionally does not store or use a cross-repository token. A
+maintainer downloads the artifact and opens the PR to
+`duckdb/community-extensions` manually. This keeps release automation read-only
+inside this repository while still making the submitted descriptor reproducible.
+
+## Descriptor Notes
+
+The descriptor intentionally marks this as a Rust cargo extension and requests
+the extra toolchains that the community CI must install:
+
+```yaml
+extension:
+  language: Rust
+  build: cargo
+  requires_toolchains: "rust;python3"
+```
+
+The descriptor excludes `wasm_mvp`, `wasm_eh`, `wasm_threads`, and
+`linux_amd64_musl`. The local distribution workflow uses the same exclusion set.
+Re-enable platforms only after the CI build and SQLLogic tests pass for them.
+
+## Submission Steps
+
+1. Ensure `main` is green for `Main Extension Distribution Pipeline` and
+   `Rust quality`.
+2. Update `CHANGELOG.md`, `Cargo.toml` version, `pyproject.toml` version, and
+   the `description.yml` version.
+3. Create and publish a GitHub Release with a tag matching the project version,
+   such as `v0.1.0`.
+4. Download the validated descriptor artifact from the `Community Extension
+   Release` workflow.
+5. Open a PR against `duckdb/community-extensions` adding or updating
+   `extensions/duckdb_zarr/description.yml` with that artifact.
+
+After the PR is merged and built by DuckDB's community infrastructure, users can
+install with:
+
+```sql
+INSTALL duckdb_zarr FROM community;
+LOAD duckdb_zarr;
+```
+
+## DuckDB Version Policy
+
+DuckDB community extensions are distributed for DuckDB's latest stable release.
+This extension currently sets `USE_UNSTABLE_C_API=1`, so the produced binary is
+not forward-compatible across DuckDB patch releases: the loader expects the exact
+DuckDB version stamped into the extension metadata.
+
+That means a DuckDB bump must update all version sites in one reviewed change:
+
+- `Makefile` `TARGET_DUCKDB_VERSION`
+- `.github/workflows/MainDistributionPipeline.yml` `duckdb_version`
+- `Cargo.toml` exact `duckdb` crate pin
+- `Cargo.lock`
+
+The local release gate checks the first three. `Cargo.lock` should change when
+`cargo update -p duckdb --precise <crate-version>` is run.
+
+The `duckdb` crate version used here encodes the DuckDB version. For the current
+pin, DuckDB `v1.5.4` maps to:
+
+```toml
+duckdb = { version = "=1.10504.0", features = ["loadable-extension"] }
+```
+
+Use the automated `DuckDB Version Drift` workflow for routine patch-line bumps.
+Treat major or minor DuckDB bumps as manual migrations: update the pins, rebuild,
+run `make lint`, and run `make test_release` before changing `description.yml`
+for community publication.
+
+## Stable vs. Current DuckDB Main
+
+Near DuckDB releases, `duckdb/community-extensions` can test extensions against
+both the latest stable release and DuckDB `main`. If one commit cannot support
+both, maintain two refs:
+
+```yaml
+repo:
+  github: xqlsystems/duckdb-zarr
+  ref: <stable-compatible-tag-or-commit>
+  ref_next: <duckdb-main-compatible-commit>
+```
+
+Use `ref` for the commit that works with the latest stable DuckDB release. Use
+`ref_next` only when DuckDB `main` needs source changes that should not replace
+the stable build yet. After DuckDB releases, the community repository can promote
+the `ref_next` commit to `ref`.

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Validate release-critical DuckDB community extension metadata."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def first_match(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text, re.MULTILINE)
+    if match is None:
+        raise ValueError(f"could not find {label}")
+    return match.group(1)
+
+
+def duckdb_crate_version(duckdb_version: str) -> str:
+    match = re.fullmatch(r"v(\d+)\.(\d+)\.(\d+)", duckdb_version)
+    if match is None:
+        raise ValueError(f"invalid DuckDB version {duckdb_version!r}")
+    _major, minor, patch = (int(part) for part in match.groups())
+    return f"1.1{minor:02d}{patch:02d}.0"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--strict-community-ref",
+        action="store_true",
+        help="fail unless description.yml repo.ref is an immutable tag or commit hash",
+    )
+    parser.add_argument(
+        "--description-path",
+        default="description.yml",
+        help="descriptor to validate, relative to the repository root",
+    )
+    args = parser.parse_args()
+
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    makefile = read("Makefile")
+    workflow = read(".github/workflows/MainDistributionPipeline.yml")
+    cargo = read("Cargo.toml")
+    description = read(args.description_path)
+
+    try:
+        make_duckdb = first_match(
+            r"^TARGET_DUCKDB_VERSION=(v\d+\.\d+\.\d+)$",
+            makefile,
+            "Makefile TARGET_DUCKDB_VERSION",
+        )
+        workflow_duckdb = first_match(
+            r"^\s*duckdb_version:\s*(v\d+\.\d+\.\d+)$",
+            workflow,
+            "workflow duckdb_version",
+        )
+        cargo_duckdb = first_match(
+            r'duckdb\s*=\s*\{\s*version\s*=\s*"=([0-9]+\.[0-9]+\.[0-9]+)"',
+            cargo,
+            "Cargo.toml duckdb crate pin",
+        )
+    except ValueError as exc:
+        failures.append(str(exc))
+    else:
+        if make_duckdb != workflow_duckdb:
+            failures.append(
+                "DuckDB version drift: "
+                f"Makefile has {make_duckdb}, workflow has {workflow_duckdb}"
+            )
+        expected_crate = duckdb_crate_version(make_duckdb)
+        if cargo_duckdb != expected_crate:
+            failures.append(
+                "DuckDB crate pin drift: "
+                f"Cargo.toml has {cargo_duckdb}, expected {expected_crate} for {make_duckdb}"
+            )
+
+    descriptor_checks = {
+        "extension.name": r"^\s*name:\s*duckdb_zarr\s*$",
+        "extension.language": r"^\s*language:\s*Rust\s*$",
+        "extension.build": r"^\s*build:\s*cargo\s*$",
+        "extension.requires_toolchains": r'^\s*requires_toolchains:\s*["\']rust;python3["\']\s*$',
+        "extension.excluded_platforms": (
+            r'^\s*excluded_platforms:\s*["\']'
+            r"wasm_mvp;wasm_eh;wasm_threads;linux_amd64_musl"
+            r'["\']\s*$'
+        ),
+    }
+    for label, pattern in descriptor_checks.items():
+        if re.search(pattern, description, re.MULTILINE) is None:
+            failures.append(f"description.yml missing or incorrect {label}")
+
+    ref = first_match(r"^\s*ref:\s*([^\s#]+)", description, "description.yml repo.ref")
+    immutable_ref = bool(re.fullmatch(r"[0-9a-f]{40}", ref) or re.fullmatch(r"v\d+\.\d+\.\d+", ref))
+    if not immutable_ref:
+        message = (
+            "description.yml repo.ref should be changed to a release tag or commit hash "
+            f"before submitting to duckdb/community-extensions; current value is {ref!r}"
+        )
+        if args.strict_community_ref:
+            failures.append(message)
+        else:
+            warnings.append(message)
+
+    if failures:
+        print("release readiness check failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    for warning in warnings:
+        print(f"warning: {warning}")
+    print("release readiness check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_community_descriptor.py
+++ b/scripts/render_community_descriptor.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Render description.yml for duckdb/community-extensions submission."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def first_match(pattern: str, text: str, label: str) -> str:
+    match = re.search(pattern, text, re.MULTILINE)
+    if match is None:
+        raise ValueError(f"could not find {label}")
+    return match.group(1)
+
+
+def project_versions() -> dict[str, str]:
+    return {
+        "Cargo.toml": first_match(
+            r'^version\s*=\s*"([^"]+)"',
+            read("Cargo.toml"),
+            "Cargo.toml package version",
+        ),
+        "pyproject.toml": first_match(
+            r'^version\s*=\s*"([^"]+)"',
+            read("pyproject.toml"),
+            "pyproject.toml project version",
+        ),
+        "description.yml": first_match(
+            r"^\s*version:\s*([^\s]+)\s*$",
+            read("description.yml"),
+            "description.yml extension version",
+        ),
+    }
+
+
+def validate_ref(ref: str, version: str) -> None:
+    if re.fullmatch(r"[0-9a-f]{40}", ref):
+        return
+    if re.fullmatch(r"v\d+\.\d+\.\d+", ref) and ref == f"v{version}":
+        return
+    raise ValueError(
+        f"release ref must be a 40-character commit hash or v{version}; got {ref!r}"
+    )
+
+
+def render(ref: str, version: str) -> str:
+    text = read("description.yml")
+
+    text = re.sub(
+        r"^(\s*version:\s*)[^\s]+(\s*)$",
+        rf"\g<1>{version}\2",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(
+        r"^(\s*)# Update ref to the tagged release commit before submitting the PR to duckdb/community-extensions\.\n",
+        "",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    text = re.sub(
+        r"^(\s*ref:\s*)[^\s#]+.*$",
+        rf"\g<1>{ref}",
+        text,
+        count=1,
+        flags=re.MULTILINE,
+    )
+    return text
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ref", required=True, help="release tag or commit hash")
+    parser.add_argument(
+        "--out",
+        required=True,
+        help="output descriptor path, relative to the repository root",
+    )
+    args = parser.parse_args()
+
+    versions = project_versions()
+    unique_versions = set(versions.values())
+    if len(unique_versions) != 1:
+        details = ", ".join(f"{path}={version}" for path, version in versions.items())
+        raise SystemExit(f"project versions differ: {details}")
+
+    version = unique_versions.pop()
+    try:
+        validate_ref(args.ref, version)
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+
+    out = ROOT / args.out
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(render(args.ref, version), encoding="utf-8")
+    print(f"wrote {out.relative_to(ROOT)} for duckdb_zarr {version} at {args.ref}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This PR readies the work in this project for releases at https://github.com/duckdb/community-extensions . Once this work is merged, I'll focus on making an initial release.