### PR TITLE
Rename community extension to zarr

### DIFF
--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -30,16 +30,16 @@ jobs:
         run: |
           uv run scripts/render_community_descriptor.py \
             --ref "$RELEASE_REF" \
-            --out build/community-extensions/extensions/duckdb_zarr/description.yml
+            --out build/community-extensions/extensions/zarr/description.yml
 
       - name: Validate rendered descriptor
         run: |
           uv run scripts/check_release_ready.py \
-            --description-path build/community-extensions/extensions/duckdb_zarr/description.yml \
+            --description-path build/community-extensions/extensions/zarr/description.yml \
             --strict-community-ref
 
       - name: Upload descriptor artifact
         uses: actions/upload-artifact@v4
         with:
-          name: duckdb_zarr-community-extension-descriptor
-          path: build/community-extensions/extensions/duckdb_zarr/description.yml
+          name: zarr-community-extension-descriptor
+          path: build/community-extensions/extensions/zarr/description.yml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Release checklist:
 4. Download the descriptor artifact from the `Community Extension Release`
    workflow.
 5. Open a PR against `duckdb/community-extensions` adding or updating
-   `extensions/duckdb_zarr/description.yml` with that artifact.
+   `extensions/zarr/description.yml` with that artifact.
 
 See [docs/community-extension-release.md](docs/community-extension-release.md)
 for the detailed release and DuckDB-version policy.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,13 @@ name = "duckdb_zarr"
 path = "src/wasm_lib.rs"
 crate-type = ["staticlib"]
 
+[[example]]
+# Community extension builds use extension.name from description.yml as
+# EXTENSION_NAME, so provide the same staticlib example under the published name.
+name = "zarr"
+path = "src/wasm_lib_zarr.rs"
+crate-type = ["staticlib"]
+
 [dependencies]
 duckdb = { version = "=1.10504.0", features = ["loadable-extension"] }
 # Base zarrs features: no blosc here — blosc_src bundles pthreads that conflict

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ release-check:
 
 render-community-descriptor:
 	@test -n "$(REF)" || (echo "Usage: make render-community-descriptor REF=v0.1.0" >&2; exit 1)
-	python3 scripts/render_community_descriptor.py --ref "$(REF)" --out build/community-extensions/extensions/duckdb_zarr/description.yml
-	python3 scripts/check_release_ready.py --description-path build/community-extensions/extensions/duckdb_zarr/description.yml --strict-community-ref
+	python3 scripts/render_community_descriptor.py --ref "$(REF)" --out build/community-extensions/extensions/zarr/description.yml
+	python3 scripts/check_release_ready.py --description-path build/community-extensions/extensions/zarr/description.yml --strict-community-ref
 
 generate_fixtures:
 	@if command -v uv >/dev/null 2>&1; then \

--- a/description.yml
+++ b/description.yml
@@ -1,5 +1,5 @@
 extension:
-  name: duckdb_zarr
+  name: zarr
   description: Query Zarr array stores (v2 and v3) with SQL — read xarray-convention datasets as tables
   version: 0.1.0
   language: Rust

--- a/docs/community-extension-release.md
+++ b/docs/community-extension-release.md
@@ -40,7 +40,7 @@ make render-community-descriptor REF=v0.1.0
 ```
 
 The rendered file is written to
-`build/community-extensions/extensions/duckdb_zarr/description.yml` with
+`build/community-extensions/extensions/zarr/description.yml` with
 `repo.ref` set to the release tag.
 
 ## GitHub Release Automation
@@ -84,14 +84,14 @@ Re-enable platforms only after the CI build and SQLLogic tests pass for them.
 4. Download the validated descriptor artifact from the `Community Extension
    Release` workflow.
 5. Open a PR against `duckdb/community-extensions` adding or updating
-   `extensions/duckdb_zarr/description.yml` with that artifact.
+   `extensions/zarr/description.yml` with that artifact.
 
 After the PR is merged and built by DuckDB's community infrastructure, users can
 install with:
 
 ```sql
-INSTALL duckdb_zarr FROM community;
-LOAD duckdb_zarr;
+INSTALL zarr FROM community;
+LOAD zarr;
 ```
 
 ## DuckDB Version Policy

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -85,7 +85,7 @@ def main() -> int:
             )
 
     descriptor_checks = {
-        "extension.name": r"^\s*name:\s*duckdb_zarr\s*$",
+        "extension.name": r"^\s*name:\s*zarr\s*$",
         "extension.language": r"^\s*language:\s*Rust\s*$",
         "extension.build": r"^\s*build:\s*cargo\s*$",
         "extension.requires_toolchains": r'^\s*requires_toolchains:\s*["\']rust;python3["\']\s*$',

--- a/scripts/render_community_descriptor.py
+++ b/scripts/render_community_descriptor.py
@@ -104,7 +104,7 @@ def main() -> int:
     out = ROOT / args.out
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(render(args.ref, version), encoding="utf-8")
-    print(f"wrote {out.relative_to(ROOT)} for duckdb_zarr {version} at {args.ref}")
+    print(f"wrote {out.relative_to(ROOT)} for zarr {version} at {args.ref}")
     return 0
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,3 +55,13 @@ pub unsafe extern "C" fn duckdb_zarr_init_c_api(
         }
     }
 }
+
+/// # Safety
+/// Entrypoint called by DuckDB for the community extension name.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn zarr_init_c_api(
+    info: duckdb::ffi::duckdb_extension_info,
+    access: *const duckdb::ffi::duckdb_extension_access,
+) -> bool {
+    unsafe { duckdb_zarr_init_c_api(info, access) }
+}

--- a/src/wasm_lib.rs
+++ b/src/wasm_lib.rs
@@ -1,6 +1,4 @@
-#![allow(special_module_name)]
-
-mod lib;
+include!("lib.rs");
 
 // To build the Wasm target, a `staticlib` crate-type is required
 //

--- a/src/wasm_lib_zarr.rs
+++ b/src/wasm_lib_zarr.rs
@@ -1,0 +1,1 @@
+include!("lib.rs");


### PR DESCRIPTION
Update community release metadata and build aliases so DuckDB community extensions publish and load this extension as zarr instead of duckdb_zarr.