### PR TITLE
Release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-08-04
+
 ### Changed
 - Target DuckDB **v1.5.5** (crate `=1.10505.0`) across the three pinned sites (`Makefile` `TARGET_DUCKDB_VERSION`, `MainDistributionPipeline.yml` `duckdb_version`, `Cargo.toml`) plus `Cargo.lock`. With `USE_UNSTABLE_C_API=1` a binary built for v1.5.4 is rejected by v1.5.5's loader (exact-version `C_STRUCT_UNSTABLE` ABI), which is why the community extension went unavailable after DuckDB 1.5.5. Compiles against 1.10505.0 with no source changes.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "zarr"
-version = "0.1.1"
+version = "0.1.3"
 dependencies = [
  "base64",
  "duckdb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zarr"
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 
 [lib]

--- a/description.yml
+++ b/description.yml
@@ -1,7 +1,7 @@
 extension:
   name: zarr
   description: Query Zarr array stores (v2 and v3) with SQL — read xarray-convention datasets as tables
-  version: 0.1.1
+  version: 0.1.3
   language: Rust
   build: cargo
   requires_toolchains: "rust;python3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "duckdb-zarr"
-version = "0.1.1"
+version = "0.1.3"
 requires-python = ">=3.11"
 dependencies = [
     "duckdb",

--- a/uv.lock
+++ b/uv.lock
@@ -170,7 +170,7 @@ wheels = [
 
 [[package]]
 name = "duckdb-zarr"
-version = "0.1.1"
+version = "0.1.3"
 source = { virtual = "." }
 dependencies = [
     { name = "duckdb" },


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml`, `pyproject.toml`, `description.yml`, and `uv.lock` from `0.1.1` to `0.1.3`.
- Cuts the `[Unreleased]` CHANGELOG section into `[0.1.3] - 2026-08-04`.

## Why 0.1.3, not 0.1.2?
`v0.1.2` was already tagged and published on GitHub (the DuckDB 1.5.5 bump, #33), but that release skipped the version-file bump step of the release checklist — `Cargo.toml`/`pyproject.toml`/`description.yml` were left at `0.1.1`, and the CHANGELOG entry stayed under `[Unreleased]`. This PR catches the version files up and folds that entry into this release alongside the new `ConsolidatedCacheStore` bind-time perf fix (#35), tagging the result `v0.1.3` since `v0.1.2` is already taken.

## Test plan
- [x] `make release-check` — passes (only the expected `repo.ref: main` warning, resolved at descriptor-render time)
- [x] `make release && make test_release` — all 5 SQLLogic suites pass (`zarr.test`, `realistic_queries.test`, `read_zarr.test`, `read_zarr_v2.test`, `bioimage_ome_zarr.test`)
- [x] CI green on this PR (Main Extension Distribution Pipeline + Rust quality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)