### PR TITLE
Fix community-release.yml: pin an existing setup-uv version

### DIFF
--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v7
 
       - name: Render descriptor for release ref
         run: |


### PR DESCRIPTION
## Summary
- `astral-sh/setup-uv@v9` doesn't exist (latest published tag is `v7`), so the `Community Extension Release` workflow's "Render community descriptor" job has failed at the "Install uv" step on every trigger since before `v0.1.2`.
- Confirmed identical `Unable to resolve action 'astral-sh/setup-uv@v9', unable to find version 'v9'` failures on both the `v0.1.2` (2026-07-27) and `v0.1.3` (2026-08-04) release-triggered runs — this had gone unnoticed because nothing checks the run status automatically.

## Fix
Pin to `v7`, the latest existing tag.

## Test plan
- [ ] Trigger `Community Extension Release` via `workflow_dispatch` with `ref=v0.1.3` (or re-run after merge) and confirm the descriptor artifact is produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)