### PR TITLE
Restore maintainer credit and docs dropped from description.yml

### DIFF
--- a/description.yml
+++ b/description.yml
@@ -9,6 +9,7 @@ extension:
   license: MIT
   maintainers:
     - alxmrs
+    - d33bs
 
 repo:
   github: xqlsystems/duckdb-zarr
@@ -17,10 +18,21 @@ repo:
 
 docs:
   hello_world: |
+    INSTALL zarr FROM community;
+    LOAD zarr;
+
     -- Read a local Zarr store as a table
     SELECT time, lat, lon, temperature
     FROM read_zarr('path/to/store.zarr')
     LIMIT 10;
+
+    -- Inspect and query a multiscale OME-Zarr bioimage
+    SELECT name, dims, shape
+    FROM read_zarr_metadata('image.ome.zarr');
+
+    SELECT c, AVG("0") AS mean_intensity
+    FROM read_zarr('image.ome.zarr', array_path = '0')
+    GROUP BY c;
   extended_description: |
     The duckdb-zarr extension exposes [Zarr](https://zarr.dev/) array stores as SQL tables,
     following the [xarray](https://xarray.dev/) dimension convention used by climate science,
@@ -52,3 +64,25 @@ docs:
       consolidated metadata — a Zarr v2 `.zmetadata` object or a Zarr v3 `consolidated_metadata`
       block — because object stores cannot list directories. S3/GCS/Azure credentials are read
       from DuckDB's secrets manager — `CREATE SECRET ... TYPE S3` etc.
+
+    **Bioimage and OME-Zarr**
+
+    OME-Zarr images commonly contain multiple resolution levels and nested label
+    arrays. Use `read_zarr_metadata` to discover store-relative array paths, then
+    pass `array_path` to select a level or label image:
+
+    ```sql
+    SELECT name, dims, shape, dtype
+    FROM read_zarr_metadata('image.ome.zarr');
+
+    SELECT c, AVG("0") AS mean_intensity
+    FROM read_zarr('image.ome.zarr', array_path = '0')
+    WHERE y BETWEEN 100 AND 199
+      AND x BETWEEN 200 AND 299
+    GROUP BY c;
+
+    SELECT "labels/nuclei/0" AS label, COUNT(*) AS pixels
+    FROM read_zarr('image.ome.zarr', array_path = 'labels/nuclei/0')
+    WHERE "labels/nuclei/0" > 0
+    GROUP BY label;
+    ```


### PR DESCRIPTION
## Summary
- `description.yml` (this repo's source of truth for the community descriptor) had drifted behind what's actually live on `duckdb/community-extensions`: missing `d33bs` from `maintainers`, missing the `INSTALL zarr FROM community; LOAD zarr;` preamble in `hello_world`, and missing the OME-Zarr bioimage walkthrough in both `hello_world` and `extended_description`.
- That content exists on the published listing today (added by hand in past community PRs — duckdb/community-extensions#1665/#2189/#2235/#2370 — never touched `docs:`/`maintainers:`, so it must predate those and was never pulled back into this repo).
- Restored both, kept this repo's own addition (the consolidated-metadata explanation for remote array listing) alongside them, so the next automated render doesn't regress the public listing again.

## Test plan
- [x] `make release-check` passes
- [x] `make render-community-descriptor REF=v0.1.3` renders and passes `check_release_ready.py --strict-community-ref`

🤖 Generated with [Claude Code](https://claude.com/claude-code)