### PR TITLE
Move to git tag dynamic releases

### DIFF
--- a/.github/workflows/community-release.yml
+++ b/.github/workflows/community-release.yml
@@ -28,10 +28,24 @@ jobs:
     steps:
       - uses: actions/checkout@v7
         with:
+          ref: ${{ env.RELEASE_REF }}
           submodules: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+
+      - name: Sync version from release tag
+        # Cargo.toml/pyproject.toml/description.yml carry a development-
+        # placeholder version (see docs/versioning.md); the tag is the real
+        # source of truth. A workflow_dispatch ref may instead be a raw commit
+        # hash (no tag to sync from), in which case the checked-in placeholder
+        # is rendered as-is.
+        run: |
+          if [[ "$RELEASE_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            uv run scripts/sync_release_version.py "$RELEASE_REF"
+          else
+            echo "RELEASE_REF '$RELEASE_REF' is not a vX.Y.Z tag; skipping version sync."
+          fi
 
       - name: Render descriptor for release ref
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,8 +75,10 @@ Release checklist:
 
 1. Confirm `Main Extension Distribution Pipeline` and `Rust quality` are green on
    the commit to publish.
-2. Update `CHANGELOG.md`, `Cargo.toml` version, `pyproject.toml` version, and
-   `description.yml` version together.
+2. Update `CHANGELOG.md` (still manual). Do **not** bump `Cargo.toml`,
+   `pyproject.toml`, or `description.yml` — they keep a development-placeholder
+   version that is synced from the release tag automatically; see
+   [docs/versioning.md](docs/versioning.md).
 3. Create and publish a GitHub Release with a tag matching the project version,
    such as `v0.1.0`.
 4. Download the descriptor artifact from the `Community Extension Release`

--- a/docs/community-extension-release.md
+++ b/docs/community-extension-release.md
@@ -22,6 +22,10 @@ in a Rust C API extension:
 - `Cargo.toml` exact `duckdb` crate pin
 - `description.yml` `language`, `build`, `requires_toolchains`, and excluded
   platforms
+- `Cargo.toml` / `pyproject.toml` / `description.yml` development-placeholder
+  versions agreeing with each other (see
+  [docs/versioning.md](versioning.md) — this does not check them against any
+  git tag; that sync happens automatically at release time)
 
 For the final community PR, also run:
 
@@ -104,8 +108,11 @@ Re-enable platforms only after the CI build and SQLLogic tests pass for them.
 
 1. Ensure `main` is green for `Main Extension Distribution Pipeline` and
    `Rust quality`.
-2. Update `CHANGELOG.md`, `Cargo.toml` version, `pyproject.toml` version, and
-   the `description.yml` version.
+2. Update `CHANGELOG.md` (still manual). Do **not** bump `Cargo.toml`,
+   `pyproject.toml`, or `description.yml` — they keep a development-placeholder
+   version that `scripts/sync_release_version.py` syncs from the release tag
+   automatically inside `community-release.yml`; see
+   [docs/versioning.md](versioning.md).
 3. Create and publish a GitHub Release with a tag matching the project version,
    such as `v0.1.0`.
 4. Download the validated descriptor artifact from the `Community Extension

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,138 @@
+# Versioning
+
+`duckdb-zarr` follows a **dynamic versioning** model: the git release tag is
+the source of truth, and the version strings checked into the repository are
+development placeholders that get synced from the tag at release time. This
+mirrors the approach used by the sibling [`arrow-lint`][arrow-lint] and
+[`zarr-lint`][zarr-lint] projects.
+
+## Two independent version concepts
+
+This project has two version numbers that are easy to conflate:
+
+1. **The DuckDB extension's own `extension_version` metadata** — stamped into
+   the compiled `.duckdb_extension` binary and reported by DuckDB at runtime.
+2. **The `Cargo.toml` / `pyproject.toml` / `description.yml` version trio** —
+   used for the community-extension descriptor and human-facing docs.
+
+They are synced independently, by two different mechanisms.
+
+### The extension's runtime version already reads the git tag
+
+DuckDB's own build tooling (`extension-ci-tools/scripts/configure_helper.py`,
+vendored as a submodule) autodetects the extension version from git and
+writes it to `configure/extension_version.txt`:
+
+```python
+git_tag = subprocess.getoutput("git tag --points-at HEAD")
+EXTENSION_VERSION = git_tag or subprocess.getoutput("git --no-pager log -1 --format=%h")
+```
+
+The `Makefile` stamps that file's contents into the compiled binary's
+metadata (`-evf configure/extension_version.txt`). This already works today,
+with no code in this repository involved — every build, including the one
+`duckdb/community-extensions` performs against this repo's tagged `ref`, is
+tied to the git tag automatically:
+
+```sql
+LOAD zarr;
+SELECT extension_version FROM duckdb_extensions() WHERE extension_name = 'zarr';
+```
+
+`configure/` is gitignored and rebuilt by `make configure`, so there is
+nothing to keep in sync by hand here — this is why the extension itself never
+needed a Rust source change to "read the git tag": `duckdb_extensions()` is
+the read path, and `zarrs`/the crate's own `Cargo.toml` `version` field never
+enters the picture. (This differs from a typical `cargo install`able binary,
+where `env!("CARGO_PKG_VERSION")` really would end up in the shipped artifact
+— it does not here, because the extension is loaded via DuckDB's C API, not
+run as a standalone binary carrying its own `--version`.)
+
+## Source of truth for the descriptor/docs trio
+
+The Cargo, Python, and community-descriptor version fields are a separate,
+purely cosmetic concern: they must agree with each other so the rendered
+`description.yml` submitted to `duckdb/community-extensions` and the
+generated docs are consistent. The committed values are **development
+placeholders** — not expected to track the latest release:
+
+```toml
+# Cargo.toml
+[package]
+version = "0.1.3"
+```
+
+```toml
+# pyproject.toml
+[project]
+version = "0.1.3"
+```
+
+```yaml
+# description.yml
+extension:
+  version: 0.1.3
+```
+
+## Verifying consistency
+
+[`scripts/check_release_ready.py`](../scripts/check_release_ready.py) runs on
+every PR (`Release metadata consistency` job in
+[`.github/workflows/rust-quality.yml`](../.github/workflows/rust-quality.yml))
+and fails if these three placeholders drift apart from each other. It does
+**not** check them against any git tag — that's not the release gate, since
+the placeholder is never expected to already equal the next tag.
+
+## Release tags
+
+Release tags use a `v` prefix; the package version omits it:
+
+| Git tag  | Package version |
+| -------- | ---------------- |
+| `v0.1.4` | `0.1.4`          |
+
+At release time,
+[`scripts/sync_release_version.py`](../scripts/sync_release_version.py)
+rewrites `Cargo.toml`, `pyproject.toml`, `description.yml`, and the `zarr`
+package entry in `Cargo.lock` to match the tag:
+
+```console
+$ python3 scripts/sync_release_version.py v0.1.4
+tag=v0.1.4 version=0.1.4: synced Cargo.toml, pyproject.toml, description.yml, Cargo.lock
+
+$ python3 scripts/sync_release_version.py v0.1.4 --check
+OK: tag v0.1.4 matches all version sites.
+```
+
+This is an **ephemeral edit**: it only runs inside
+[`.github/workflows/community-release.yml`](../.github/workflows/community-release.yml)'s
+CI checkout, right before rendering the community descriptor, and is never
+committed. The repository keeps its development-placeholder version between
+releases — publishing a release no longer requires a manual `Cargo.toml` /
+`pyproject.toml` / `description.yml` bump beforehand, only a `CHANGELOG.md`
+entry (still maintained by hand; see
+[`CHANGELOG.md`](../CHANGELOG.md)) and the tag itself.
+
+If a `workflow_dispatch` run targets a raw commit hash instead of a tag (the
+`description.yml` `repo.ref` "publish an older/manual ref" path), there is no
+tag to sync from, so the sync step is skipped and the checked-in placeholder
+is rendered as-is — the same behavior this workflow had before dynamic
+versioning existed.
+
+## Why not release-plz?
+
+[release-plz](https://release-plz.dev/) automates conventional-commit-driven
+version bumps, changelog generation, and crates.io publishing via release
+PRs. It was considered for this issue but doesn't fit `duckdb-zarr`: this
+crate is never published to crates.io (it's a `cdylib` C API extension, not a
+library), the build is version-locked to an exact DuckDB release
+(`USE_UNSTABLE_C_API=1`, see
+[`docs/community-extension-release.md`](community-extension-release.md#duckdb-version-policy)),
+and the three-file descriptor trio it would still need a custom step for is
+exactly what `sync_release_version.py` already handles. The
+placeholder-plus-tag-sync pattern from `arrow-lint`/`zarr-lint` covers the
+same need with less new surface area and matches the pattern already proven
+in this maintainer's other projects.
+
+[arrow-lint]: https://github.com/d33bs/arrow-lint
+[zarr-lint]: https://github.com/d33bs/zarr-lint

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -94,7 +94,8 @@ Release tags use a `v` prefix; the package version omits it:
 At release time,
 [`scripts/sync_release_version.py`](../scripts/sync_release_version.py)
 rewrites `Cargo.toml`, `pyproject.toml`, `description.yml`, and the `zarr`
-package entry in `Cargo.lock` to match the tag:
+package entry in `Cargo.lock` to match the tag, inside the release workflow's
+CI checkout — **no commit is made to `main` (or any branch)**:
 
 ```console
 $ python3 scripts/sync_release_version.py v0.1.4
@@ -112,6 +113,13 @@ releases — publishing a release no longer requires a manual `Cargo.toml` /
 `pyproject.toml` / `description.yml` bump beforehand, only a `CHANGELOG.md`
 entry (still maintained by hand; see
 [`CHANGELOG.md`](../CHANGELOG.md)) and the tag itself.
+
+Committing the synced version back to `main` was considered and rejected: it
+would require the release workflow to push a commit (or open a PR) after
+every tag, adding a second source of truth that could drift from the tag it
+was derived from, plus bot-authored commits/PRs to review on every release.
+Leaving the sync ephemeral keeps the git tag as the single source of truth
+and matches the pattern already proven in `arrow-lint`/`zarr-lint`.
 
 If a `workflow_dispatch` run targets a raw commit hash instead of a tag (the
 `description.yml` `repo.ref` "publish an older/manual ref" path), there is no

--- a/scripts/check_release_ready.py
+++ b/scripts/check_release_ready.py
@@ -51,6 +51,12 @@ def main() -> int:
     makefile = read("Makefile")
     workflow = read(".github/workflows/MainDistributionPipeline.yml")
     cargo = read("Cargo.toml")
+    pyproject = read("pyproject.toml")
+    # The repo's own description.yml, independent of --description-path: the
+    # project-version-agreement check below is about the checked-in
+    # development-placeholder trio, not whichever descriptor is being
+    # validated (which may be a tag-synced render under build/).
+    root_description = read("description.yml")
     description = read(args.description_path)
 
     try:
@@ -83,6 +89,36 @@ def main() -> int:
                 "DuckDB crate pin drift: "
                 f"Cargo.toml has {cargo_duckdb}, expected {expected_crate} for {make_duckdb}"
             )
+
+    # Cargo.toml / pyproject.toml / description.yml carry a development-
+    # placeholder version (see docs/versioning.md) that is only ever rewritten
+    # by scripts/sync_release_version.py at release-build time, never
+    # committed. This does not check it against any git tag — it only
+    # guards that the three checked-in placeholders can't silently drift
+    # apart from each other between releases.
+    try:
+        project_versions = {
+            "Cargo.toml": first_match(
+                r'^version\s*=\s*"([^"]+)"', cargo, "Cargo.toml package version"
+            ),
+            "pyproject.toml": first_match(
+                r'^version\s*=\s*"([^"]+)"', pyproject, "pyproject.toml project version"
+            ),
+            "description.yml": first_match(
+                r"^\s*version:\s*([^\s]+)\s*$",
+                root_description,
+                "description.yml extension version",
+            ),
+        }
+    except ValueError as exc:
+        failures.append(str(exc))
+    else:
+        distinct_versions = set(project_versions.values())
+        if len(distinct_versions) != 1:
+            details = ", ".join(
+                f"{path}={version}" for path, version in project_versions.items()
+            )
+            failures.append(f"project versions differ: {details}")
 
     descriptor_checks = {
         "extension.name": r"^\s*name:\s*zarr\s*$",

--- a/scripts/sync_release_version.py
+++ b/scripts/sync_release_version.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Synchronize the project version with a release tag.
+
+`duckdb-zarr` keeps a single authoritative version repeated across three
+files — `Cargo.toml`, `pyproject.toml`, and `description.yml` — plus the
+`zarr` package entry in `Cargo.lock`. The committed value is a *development
+placeholder*; it is not expected to track the latest release. At release
+time the git tag (for example `v0.1.4`) is the source of truth: this script
+rewrites all four sites to match the tag in the CI checkout. Nothing is
+committed — the rewrite lives only in the ephemeral release build checkout,
+so the published community descriptor and docs carry the tag version while
+the repository keeps its development placeholder.
+
+This mirrors the dynamic-versioning approach used by the sibling
+[`arrow-lint`](https://github.com/d33bs/arrow-lint) and
+[`zarr-lint`](https://github.com/d33bs/zarr-lint) projects — see
+docs/versioning.md.
+
+Usage::
+
+    python3 scripts/sync_release_version.py v0.1.4        # rewrite
+    python3 scripts/sync_release_version.py v0.1.4 --check  # verify only
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+TAG_PATTERN = re.compile(r"^v(?P<version>\d+\.\d+\.\d+)$")
+
+
+@dataclass(frozen=True)
+class Site:
+    path: str
+    # Matches the single standalone version line/block for this file. Anchored
+    # so it never matches a dependency's inline `version = "..."` (e.g.
+    # Cargo.toml's `zarrs = { version = "0.23", ... }`, which is not a bare
+    # `^version = "..."$` line).
+    pattern: re.Pattern[str]
+    # Rewrites `match` to embed `version`, returning the full replacement text.
+    render: Callable[[re.Match[str], str], str]
+
+
+def _render_toml(match: re.Match[str], version: str) -> str:
+    return f'version = "{version}"'
+
+
+def _render_description_yml(match: re.Match[str], version: str) -> str:
+    return f"{match.group(1)}version: {version}"
+
+
+def _render_cargo_lock(match: re.Match[str], version: str) -> str:
+    return f'{match.group(1)}"{version}"'
+
+
+SITES: list[Site] = [
+    Site(
+        "Cargo.toml",
+        re.compile(r'^version = "\d+\.\d+\.\d+"$', re.MULTILINE),
+        _render_toml,
+    ),
+    Site(
+        "pyproject.toml",
+        re.compile(r'^version = "\d+\.\d+\.\d+"$', re.MULTILINE),
+        _render_toml,
+    ),
+    Site(
+        "description.yml",
+        re.compile(r"^(\s*)version:\s*\S+\s*$", re.MULTILINE),
+        _render_description_yml,
+    ),
+    Site(
+        "Cargo.lock",
+        re.compile(r'(\[\[package\]\]\nname = "zarr"\nversion = )"\d+\.\d+\.\d+"'),
+        _render_cargo_lock,
+    ),
+]
+
+
+def version_from_tag(tag: str) -> str:
+    match = TAG_PATTERN.fullmatch(tag)
+    if not match:
+        raise SystemExit(f"release tag must look like v1.2.3: {tag}")
+    return match.group("version")
+
+
+def read_version(site: Site, root: Path) -> str:
+    text = (root / site.path).read_text(encoding="utf-8")
+    match = site.pattern.search(text)
+    if match is None:
+        raise SystemExit(f"could not find a version line in {site.path}")
+    version_match = re.search(r"\d+\.\d+\.\d+", match.group(0))
+    if version_match is None:
+        raise SystemExit(f"could not parse version out of {site.path}")
+    return version_match.group(0)
+
+
+def current_versions(root: Path) -> dict[str, str]:
+    return {site.path: read_version(site, root) for site in SITES}
+
+
+def rewrite(site: Site, version: str, root: Path) -> None:
+    path = root / site.path
+    text = path.read_text(encoding="utf-8")
+    new_text, count = site.pattern.subn(
+        lambda match: site.render(match, version), text, count=1
+    )
+    if count != 1:
+        raise SystemExit(f"could not find a version line to rewrite in {site.path}")
+    path.write_text(new_text, encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tag", help="release tag, for example v0.1.4")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="verify the tag against the current version sites without editing",
+    )
+    parser.add_argument(
+        "--root",
+        default=str(ROOT),
+        help=argparse.SUPPRESS,  # test-only escape hatch; defaults to the repo root
+    )
+    args = parser.parse_args()
+    root = Path(args.root)
+
+    version = version_from_tag(args.tag)
+
+    if args.check:
+        mismatches = {
+            name: found for name, found in current_versions(root).items() if found != version
+        }
+        if mismatches:
+            details = ", ".join(f"{name}={found}" for name, found in mismatches.items())
+            raise SystemExit(f"tag {args.tag} does not match version sites: {details}")
+        print(f"OK: tag {args.tag} matches all version sites.")
+        return 0
+
+    for site in SITES:
+        rewrite(site, version, root)
+
+    mismatches = {
+        name: found for name, found in current_versions(root).items() if found != version
+    }
+    if mismatches:
+        details = ", ".join(f"{name}={found}" for name, found in mismatches.items())
+        raise SystemExit(f"rewrite verification failed: {details}")
+
+    sites = ", ".join(site.path for site in SITES)
+    print(f"tag={args.tag} version={version}: synced {sites}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/sql/read_zarr.test
+++ b/test/sql/read_zarr.test
@@ -397,3 +397,14 @@ FROM (SELECT air FROM read_zarr('test/fixtures/xarray_tutorial/air_temperature.z
 ----
 1088175738.000000
 
+# ── extension version ───────────────────────────────────────────────────────
+# extension_version is stamped at build time from `git tag --points-at HEAD`
+# (falling back to the short commit hash) by extension-ci-tools' configure
+# step — see docs/versioning.md. Just assert it's populated; the exact value
+# is build-environment-dependent.
+
+query I
+SELECT length(extension_version) > 0 FROM duckdb_extensions() WHERE extension_name = 'zarr';
+----
+true
+

--- a/test/test_sync_release_version.py
+++ b/test/test_sync_release_version.py
@@ -1,0 +1,113 @@
+"""Unit tests for scripts/sync_release_version.py.
+
+Runs the script as a subprocess against a scratch `--root` directory (never
+the real repository files) covering rewrite and --check for all four version
+sites, plus the guard against a dependency's inline `version = "..."` being
+mistaken for the package version.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).parent.parent
+SCRIPT = ROOT / "scripts" / "sync_release_version.py"
+
+CARGO_TOML = """\
+[package]
+name = "zarr"
+version = "0.1.3"
+edition = "2021"
+
+[dependencies]
+zarrs = { version = "0.23", default-features = false, features = ["ndarray"] }
+"""
+
+PYPROJECT_TOML = """\
+[project]
+name = "duckdb-zarr"
+version = "0.1.3"
+requires-python = ">=3.11"
+"""
+
+DESCRIPTION_YML = """\
+extension:
+  name: zarr
+  version: 0.1.3
+  language: Rust
+"""
+
+CARGO_LOCK = """\
+[[package]]
+name = "other-crate"
+version = "9.9.9"
+
+[[package]]
+name = "zarr"
+version = "0.1.3"
+dependencies = [
+ "base64",
+]
+"""
+
+
+@pytest.fixture()
+def scratch_root(tmp_path: pathlib.Path) -> pathlib.Path:
+    (tmp_path / "Cargo.toml").write_text(CARGO_TOML, encoding="utf-8")
+    (tmp_path / "pyproject.toml").write_text(PYPROJECT_TOML, encoding="utf-8")
+    (tmp_path / "description.yml").write_text(DESCRIPTION_YML, encoding="utf-8")
+    (tmp_path / "Cargo.lock").write_text(CARGO_LOCK, encoding="utf-8")
+    return tmp_path
+
+
+def run_sync(*args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_check_fails_when_placeholder_does_not_match_tag(scratch_root: pathlib.Path) -> None:
+    result = run_sync("v0.1.9", "--check", "--root", str(scratch_root))
+    assert result.returncode != 0
+    assert "does not match version sites" in result.stderr
+
+
+def test_rewrite_updates_all_four_sites(scratch_root: pathlib.Path) -> None:
+    result = run_sync("v0.1.9", "--root", str(scratch_root))
+    assert result.returncode == 0, result.stderr
+
+    cargo_toml = (scratch_root / "Cargo.toml").read_text(encoding="utf-8")
+    assert 'name = "zarr"\nversion = "0.1.9"' in cargo_toml
+    # The dependency's inline version must be untouched.
+    assert 'zarrs = { version = "0.23"' in cargo_toml
+
+    pyproject = (scratch_root / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.1.9"' in pyproject
+
+    description = (scratch_root / "description.yml").read_text(encoding="utf-8")
+    assert "  version: 0.1.9" in description
+
+    cargo_lock = (scratch_root / "Cargo.lock").read_text(encoding="utf-8")
+    assert 'name = "zarr"\nversion = "0.1.9"' in cargo_lock
+    # The unrelated lockfile entry must be untouched.
+    assert 'name = "other-crate"\nversion = "9.9.9"' in cargo_lock
+
+
+def test_check_passes_after_rewrite(scratch_root: pathlib.Path) -> None:
+    run_sync("v0.1.9", "--root", str(scratch_root))
+    result = run_sync("v0.1.9", "--check", "--root", str(scratch_root))
+    assert result.returncode == 0, result.stderr
+    assert "OK" in result.stdout
+
+
+@pytest.mark.parametrize("bad_tag", ["0.1.9", "v0.1", "v0.1.9-rc1"])
+def test_rejects_tags_that_are_not_vx_y_z(scratch_root: pathlib.Path, bad_tag: str) -> None:
+    result = run_sync(bad_tag, "--root", str(scratch_root))
+    assert result.returncode != 0
+    assert "must look like v1.2.3" in result.stderr


### PR DESCRIPTION
Adds capabilities to use git tags for dynamic versioning, lowering the need for code-based version updates.

Closes #28 